### PR TITLE
Fix Null Reference Exception when Saving Entities without a DbContext

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.IO;
-using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsReverseEngineerScaffolder.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsReverseEngineerScaffolder.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+// Modifications copyright(C) 2018 Tony Sneed.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+namespace EntityFrameworkCore.Scaffolding.Handlebars
+{
+    /// <summary>
+    /// Scaffolding for persisting generated DbContext and entity type classes using Handlebars templates.
+    /// </summary>
+    public class HbsReverseEngineerScaffolder : ReverseEngineerScaffolder
+    {
+        /// <summary>
+        /// Constructor for the HbsCSharpModelGenerator.
+        /// </summary>
+        /// <param name="databaseModelFactory">Service to reverse engineer a database into a database model.</param>
+        /// <param name="scaffoldingModelFactory">Factory to create a scaffolding model.</param>
+        /// <param name="modelCodeGeneratorSelector">Selects a model code generator service for a given programming language.</param>
+        /// <param name="cSharpUtilities">C# utilities.</param>
+        /// <param name="cSharpHelper">C# helper.</param>
+        /// <param name="connectionStringResolver">Connection string resolver.</param>
+        public HbsReverseEngineerScaffolder(
+            IDatabaseModelFactory databaseModelFactory,
+            IScaffoldingModelFactory scaffoldingModelFactory,
+            IModelCodeGeneratorSelector modelCodeGeneratorSelector,
+            ICSharpUtilities cSharpUtilities,
+            ICSharpHelper cSharpHelper,
+            INamedConnectionStringResolver connectionStringResolver) : base(databaseModelFactory, scaffoldingModelFactory, modelCodeGeneratorSelector, cSharpUtilities, cSharpHelper, connectionStringResolver)
+        {
+        }
+
+        /// <summary>
+        /// Persist generated DbContext and entity type classes. 
+        /// </summary>
+        /// <param name="scaffoldedModel">Represents a scaffolded model.</param>
+        /// <param name="outputDir">Output directory.</param>
+        /// <param name="overwriteFiles">True to overwrite existing files.</param>
+        /// <returns></returns>
+        public override SavedModelFiles Save(ScaffoldedModel scaffoldedModel, string outputDir, bool overwriteFiles)
+        {
+            CheckOutputFiles(scaffoldedModel, outputDir, overwriteFiles);
+
+            Directory.CreateDirectory(outputDir);
+
+            var contextPath = string.Empty;
+            if (scaffoldedModel.ContextFile != null
+                && !string.IsNullOrWhiteSpace(scaffoldedModel.ContextFile.Path))
+            {
+                contextPath = Path.GetFullPath(Path.Combine(outputDir, scaffoldedModel.ContextFile.Path));
+                Directory.CreateDirectory(Path.GetDirectoryName(contextPath));
+                File.WriteAllText(contextPath, scaffoldedModel.ContextFile.Code, Encoding.UTF8);
+            }
+
+            var additionalFiles = new List<string>();
+            foreach (var entityTypeFile in scaffoldedModel.AdditionalFiles)
+            {
+                var additionalFilePath = Path.Combine(outputDir, entityTypeFile.Path);
+                File.WriteAllText(additionalFilePath, entityTypeFile.Code, Encoding.UTF8);
+                additionalFiles.Add(additionalFilePath);
+            }
+
+            return new SavedModelFiles(contextPath, additionalFiles);
+        }
+
+        private static void CheckOutputFiles(
+            ScaffoldedModel scaffoldedModel,
+            string outputDir,
+            bool overwriteFiles)
+        {
+            var paths = scaffoldedModel.AdditionalFiles.Select(f => f.Path).ToList();
+            if (scaffoldedModel.ContextFile != null
+                && !string.IsNullOrWhiteSpace(scaffoldedModel.ContextFile.Path))
+            paths.Insert(0, scaffoldedModel.ContextFile.Path);
+
+            var existingFiles = new List<string>();
+            var readOnlyFiles = new List<string>();
+            foreach (var path in paths)
+            {
+                var fullPath = Path.Combine(outputDir, path);
+
+                if (File.Exists(fullPath))
+                {
+                    existingFiles.Add(path);
+
+                    if (File.GetAttributes(fullPath).HasFlag(FileAttributes.ReadOnly))
+                    {
+                        readOnlyFiles.Add(path);
+                    }
+                }
+            }
+
+            if (!overwriteFiles && existingFiles.Count != 0)
+            {
+                throw new OperationException(
+                    DesignStrings.ExistingFiles(
+                        outputDir,
+                        string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, existingFiles)));
+            }
+            if (readOnlyFiles.Count != 0)
+            {
+                throw new OperationException(
+                    DesignStrings.ReadOnlyFiles(
+                        outputDir,
+                        string.Join(CultureInfo.CurrentCulture.TextInfo.ListSeparator, readOnlyFiles)));
+            }
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -67,6 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Design
                 return new HbsHelperService(helpers);
             });
             services.AddSingleton<IModelCodeGenerator, HbsCSharpModelGenerator>();
+            services.AddSingleton<IReverseEngineerScaffolder, HbsReverseEngineerScaffolder>();
             return services;
         }
     }

--- a/test/Scaffolding.Handlebars.Tests/Helpers/TempDirectory.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/TempDirectory.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.IO;
+using IOPath = System.IO.Path;
+
+namespace Scaffolding.Handlebars.Tests.Helpers
+{
+    public class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = IOPath.Combine(IOPath.GetTempPath(), IOPath.GetRandomFileName());
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+            => Directory.Delete(Path, recursive: true);
+    }
+}

--- a/test/Scaffolding.Handlebars.Tests/ReverseEngineeringConfigurationTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/ReverseEngineeringConfigurationTests.cs
@@ -41,6 +41,7 @@ namespace Scaffolding.Handlebars.Tests
                 .AddSingleton<IDbContextTemplateService, HbsDbContextTemplateService>()
                 .AddSingleton<ITemplateFileService, InMemoryTemplateFileService>()
                 .AddSingleton<IEntityTypeTemplateService, HbsEntityTypeTemplateService>()
+                .AddSingleton<IReverseEngineerScaffolder, HbsReverseEngineerScaffolder>()
                 .AddSingleton<IHbsHelperService>(provider => new HbsHelperService(
                     new Dictionary<string, Action<TextWriter, object, object[]>>
                     {


### PR DESCRIPTION
Resolve #23 NullReferenceException in CheckOutputFiles.
- Refactor tests to create scaffolder separately.
- Extend ReverseEngineerScaffolder to allow saving of entities without a DbContext.
