### PR TITLE
Make context argument of Handlebars helper method strongly typed

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ Scaffold EF Core models using Handlebars templates.
 
 You can register Handlebars helpers in the `ScaffoldingDesignTimeServices` where setup takes place.
 - Create a named tuple as shown with `myHelper` below.
+- The `context` parameter of the helper method provides model data injected by the Handlebars scaffolding extension.
 - Pass the tuple to the `AddHandlebarsHelpers` extension method.
+- To use Handlebars helper defined above, add the following to any of the .hbs files within the CodeTemplates folder: `{{my-helper}}`
 - You may register as many helpers as you wish.
 
 You can pass transform functions to `AddHandlebarsTransformers` in order to customize generation of entity type definitions, including class names, constructors and properties.
@@ -93,23 +95,29 @@ public class ScaffoldingDesignTimeServices : IDesignTimeServices
         // Add optional Handlebars helpers
         services.AddHandlebarsHelpers(myHelper);
 
-        // Add optional Handlebars transformers
+        // Add Handlebars transformer for Country property
         services.AddHandlebarsTransformers(
-            entityNameTransformer: n => n + "Foo",
-            entityFileNameTransformer: n => n + "Foo",
-            constructorTransformer: e => new EntityPropertyInfo(e.PropertyType + "Foo", e.PropertyName + "Foo"),
-            propertyTransformer: e => new EntityPropertyInfo(e.PropertyType, e.PropertyName + "Foo"),
-            navPropertyTransformer: e => new EntityPropertyInfo(e.PropertyType + "Foo", e.PropertyName + "Foo"));
+            propertyTransformer: e =>
+                e.PropertyName == "Country"
+                    ? new EntityPropertyInfo("Country", e.PropertyName)
+                    : new EntityPropertyInfo(e.PropertyType, e.PropertyName));
+
+        // Add optional Handlebars transformers
+        //services.AddHandlebarsTransformers(
+        //    entityNameTransformer: n => n + "Foo",
+        //    entityFileNameTransformer: n => n + "Foo",
+        //    constructorTransformer: e => new EntityPropertyInfo(e.PropertyType + "Foo", e.PropertyName + "Foo"),
+        //    propertyTransformer: e => new EntityPropertyInfo(e.PropertyType, e.PropertyName + "Foo"),
+        //    navPropertyTransformer: e => new EntityPropertyInfo(e.PropertyType + "Foo", e.PropertyName + "Foo"));
     }
 
     // Sample Handlebars helper
-    void MyHbsHelper(TextWriter writer, object context, object[] parameters)
+    void MyHbsHelper(TextWriter writer, Dictionary<string, object> context, object[] parameters)
     {
         writer.Write("// My Handlebars Helper");
     }
 }
 ```
-- To use Handlebars helper defined above, add the following to any of the .hbs files within the CodeTemplates folder: `{{my-helper}}`
 
 ## Extending the OnModelCreating Method
 

--- a/sample/ScaffoldingSample/Sample.ReadMe.md
+++ b/sample/ScaffoldingSample/Sample.ReadMe.md
@@ -54,7 +54,7 @@ public class ScaffoldingDesignTimeServices : IDesignTimeServices
     }
 
     // Sample Handlebars helper
-    void MyHbsHelper(TextWriter writer, object context, object[] parameters)
+    void MyHbsHelper(TextWriter writer, Dictionary<string, object> context, object[] parameters)
     {
         writer.Write("// My Handlebars Helper");
     }

--- a/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using EntityFrameworkCore.Scaffolding.Handlebars;
@@ -22,7 +23,7 @@ namespace ScaffoldingSample
             var options = ReverseEngineerOptions.DbContextAndEntities;
 
             // Register Handlebars helper
-            var myHelper = (helperName: "my-helper", helperFunction: (Action<TextWriter, object, object[]>) MyHbsHelper);
+            var myHelper = (helperName: "my-helper", helperFunction: (Action<TextWriter, Dictionary<string, object>, object[]>) MyHbsHelper);
 
             // Add Handlebars scaffolding templates
             services.AddHandlebarsScaffolding(options);
@@ -47,7 +48,7 @@ namespace ScaffoldingSample
         }
 
         // Sample Handlebars helper
-        void MyHbsHelper(TextWriter writer, object context, object[] parameters)
+        void MyHbsHelper(TextWriter writer, Dictionary<string, object> context, object[] parameters)
         {
             writer.Write("// My Handlebars Helper");
         }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsHelperService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsHelperService.cs
@@ -13,14 +13,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Handlebars helpers.
         /// </summary>
-        public Dictionary<string, Action<TextWriter, object, object[]>> Helpers { get; }
+        public Dictionary<string, Action<TextWriter, Dictionary<string, object>, object[]>> Helpers { get; }
 
         /// <summary>
         /// Constructor for the Handlebars helper service.
         /// </summary>
         /// <param name="helpers">Dictionary of Handlebars helpers.</param>
         public HbsHelperService(
-            Dictionary<string, Action<TextWriter, object, object[]>> helpers)
+            Dictionary<string, Action<TextWriter, Dictionary<string, object>, object[]>> helpers)
         {
             Helpers = helpers;
         }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/Helpers/HandlebarsHelpers.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/Helpers/HandlebarsHelpers.cs
@@ -12,7 +12,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Helpers
         /// Get the spaces Handlebars helper.
         /// </summary>
         /// <returns>Spaces Handlebars helper.</returns>
-        public static Action<TextWriter, object, object[]> SpacesHelper
+        public static Action<TextWriter, dynamic, object[]> SpacesHelper
             => (writer, context, parameters) =>
             {
                 var spaces = string.Empty;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IHbsHelperService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IHbsHelperService.cs
@@ -12,7 +12,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Handlebars helpers.
         /// </summary>
-        Dictionary<string, Action<TextWriter, object, object[]>> Helpers { get; }
+        Dictionary<string, Action<TextWriter, Dictionary<string, object>, object[]>> Helpers { get; }
 
         /// <summary>
         /// Register Handlebars helpers.

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -72,11 +72,11 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="handlebarsHelpers">Handlebars helpers.</param>
         /// <returns>The same service collection so that multiple calls can be chained.</returns>
         public static IServiceCollection AddHandlebarsHelpers(this IServiceCollection services,
-            params (string helperName, Action<TextWriter, object, object[]> helperFunction)[] handlebarsHelpers)
+            params (string helperName, Action<TextWriter, Dictionary<string, object>, object[]> helperFunction)[] handlebarsHelpers)
         {
             services.AddSingleton<IHbsHelperService>(provider =>
             {
-                var helpers = new Dictionary<string, Action<TextWriter, object, object[]>>
+                var helpers = new Dictionary<string, Action<TextWriter, Dictionary<string, object>, object[]>>
                 {
                     {Constants.SpacesHelper, HandlebarsHelpers.SpacesHelper}
                 };

--- a/test/Scaffolding.Handlebars.Tests/Fakes/TestProviderCodeGenerator.cs
+++ b/test/Scaffolding.Handlebars.Tests/Fakes/TestProviderCodeGenerator.cs
@@ -15,7 +15,9 @@ namespace Scaffolding.Handlebars.Tests.Fakes
         {
         }
 
+#pragma warning disable 672
         public override MethodCallCodeFragment GenerateUseProvider(string connectionString)
+#pragma warning restore 672
             => new MethodCallCodeFragment("UseTestProvider", connectionString);
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
@@ -351,7 +351,7 @@ namespace Scaffolding.Handlebars.Tests
                         : new NullCSharpEntityTypeGenerator();
                 })
                 .AddSingleton<IHbsHelperService>(provider =>
-                new HbsHelperService(new Dictionary<string, Action<TextWriter, object, object[]>>
+                new HbsHelperService(new Dictionary<string, Action<TextWriter, Dictionary<string, object>, object[]>>
                 {
                     {EntityFrameworkCore.Scaffolding.Handlebars.Helpers.Constants.SpacesHelper, HandlebarsHelpers.SpacesHelper}
                 }))

--- a/test/Scaffolding.Handlebars.Tests/ReverseEngineeringConfigurationTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/ReverseEngineeringConfigurationTests.cs
@@ -44,7 +44,7 @@ namespace Scaffolding.Handlebars.Tests
                 .AddSingleton<IReverseEngineerScaffolder, HbsReverseEngineerScaffolder>()
                 .AddSingleton<IEntityTypeTransformationService, HbsEntityTypeTransformationService>()
                 .AddSingleton<IHbsHelperService>(provider => new HbsHelperService(
-                    new Dictionary<string, Action<TextWriter, object, object[]>>
+                    new Dictionary<string, Action<TextWriter, Dictionary<string, object>, object[]>>
                     {
                         {Constants.SpacesHelper, HandlebarsHelpers.SpacesHelper}
                     }))


### PR DESCRIPTION
Change `context` argument type to `Dictionary<string, object>` so that model metadata is easier to use in helper methods.