### PR TITLE
Add DbContext constructor partial template (fixes #32)

### DIFF
--- a/sample/ScaffoldingSample/CodeTemplates/CSharpDbContext/DbContext.hbs
+++ b/sample/ScaffoldingSample/CodeTemplates/CSharpDbContext/DbContext.hbs
@@ -4,13 +4,15 @@ namespace {{namespace}}
 { // Comment
     public partial class {{class}} : DbContext
     {
-{{> dbsets}}
+{{{> dbsets}}}
 {{#if entity-type-errors}}
 {{#each entity-type-errors}}
 {{spaces 8}}{{{entity-type-error}}}
 {{/each}}
 
 {{/if}}
+
+{{{> dbconstructor}}}
 
 {{{on-model-creating}}}
     }

--- a/sample/ScaffoldingSample/CodeTemplates/CSharpDbContext/Partials/DbConstructor.hbs
+++ b/sample/ScaffoldingSample/CodeTemplates/CSharpDbContext/Partials/DbConstructor.hbs
@@ -1,0 +1,3 @@
+﻿{{spaces 8}}public {{class}}(DbContextOptions<{{class}}> options) : base(options)
+{{spaces 8}}{
+{{spaces 7}} }

--- a/sample/ScaffoldingSample/Contexts/NorthwindSlimContext.cs
+++ b/sample/ScaffoldingSample/Contexts/NorthwindSlimContext.cs
@@ -25,6 +25,10 @@ namespace ScaffoldingSample.Models
         // My Handlebars Helper
         public virtual DbSet<Territory> Territory { get; set; }
 
+        public NorthwindSlimContext(DbContextOptions<NorthwindSlimContext> options) : base(options)
+        {
+        }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.HasAnnotation("ProductVersion", "2.2.0-rtm-35687");

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpDbContext/DbContext.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpDbContext/DbContext.hbs
@@ -4,13 +4,16 @@ namespace {{namespace}}
 {
     public partial class {{class}} : DbContext
     {
-{{> dbsets}}
+{{{> dbconstructor}}}
+{{{> dbsets}}}
 {{#if entity-type-errors}}
 {{#each entity-type-errors}}
 {{spaces 8}}{{{entity-type-error}}}
 {{/each}}
 
 {{/if}}
+
+{{{> dbconstructor}}}
 
 {{{on-configuring}}}
 {{{on-model-creating}}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpDbContext/Partials/DbConstructor.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpDbContext/Partials/DbConstructor.hbs
@@ -1,0 +1,3 @@
+﻿{{spaces 8}}public {{class}}(DbContextOptions<{{class}}> options) : base(options)
+{{spaces 8}}{
+{{spaces 7}} }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
@@ -8,6 +8,6 @@ namespace {{namespace}}
     public partial class {{class}}
     {
         {{{> constructor}}}
-        {{> properties}}
+        {{{> properties}}}
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -29,11 +29,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="CodeTemplates\CSharpEntityType\Partials\Constructor - Copy.hbs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- pack  tempate files -->
     <Content Include="CodeTemplates\CSharpDbContext\DbContext.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpDbContext\" />
     <Content Include="CodeTemplates\CSharpDbContext\Partials\DbImports.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpDbContext\Partials\" />
     <Content Include="CodeTemplates\CSharpDbContext\Partials\DbSets.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpDbContext\Partials\" />
     <Content Include="CodeTemplates\CSharpEntityType\Class.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpEntityType\" />
+    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbConstructor.hbs">
+      <PackagePath>lib\netstandard2.0\CodeTemplates\CSharpEntityType\Partials\</PackagePath>
+    </Content>
     <Content Include="CodeTemplates\CSharpEntityType\Partials\Constructor.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpEntityType\Partials\" />
     <Content Include="CodeTemplates\CSharpEntityType\Partials\Imports.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpEntityType\Partials\" />
     <Content Include="CodeTemplates\CSharpEntityType\Partials\Properties.hbs" PackagePath="lib\netstandard2.0\CodeTemplates\CSharpEntityType\Partials\" />

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsDbContextTemplateService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsDbContextTemplateService.cs
@@ -60,6 +60,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             var importTemplate = FileService.RetrieveTemplateFileContents(
                 Constants.DbContextPartialsDirectory,
                 Constants.DbContextImportTemplate + Constants.TemplateExtension);
+            var ctorTemplate = FileService.RetrieveTemplateFileContents(
+                Constants.DbContextPartialsDirectory,
+                Constants.DbContextCtorTemplate + Constants.TemplateExtension);
             var propertyTemplate = FileService.RetrieveTemplateFileContents(
                 Constants.DbContextPartialsDirectory,
                 Constants.DbContextDbSetsTemplate + Constants.TemplateExtension);
@@ -69,6 +72,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     Constants.DbContextImportTemplate.ToLower(),
                     importTemplate
+                },
+                {
+                    Constants.DbContextCtorTemplate.ToLower(),
+                    ctorTemplate
                 },
                 {
                     Constants.DbContextDbSetsTemplate.ToLower(),

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/Helpers/Constants.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/Helpers/Constants.cs
@@ -44,6 +44,9 @@
         /// <summary>DbContext imports template.</summary>
         public const string DbContextImportTemplate = "DbImports";
 
+        /// <summary>DbContext constructor template.</summary>
+        public const string DbContextCtorTemplate = "DbConstructor";
+
         /// <summary>DbContext DbSets template.</summary>
         public const string DbContextDbSetsTemplate = "DbSets";
     }


### PR DESCRIPTION
Add a constructor to the DbContext template using a partial template that can be customized.