### PR TITLE
Added block helpers support

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsBlockHelperService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsBlockHelperService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using HandlebarsDotNet;
+
+namespace EntityFrameworkCore.Scaffolding.Handlebars
+{
+    /// <summary>
+    /// Provide services required to register Handlebars block helpers.
+    /// </summary>
+    public class HbsBlockHelperService : IHbsBlockHelperService
+    {
+        /// <summary>
+        /// Handlebars block helpers.
+        /// </summary>
+        public Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>> Helpers { get; }
+
+        /// <summary>
+        /// Constructor for the Handlebars block helper service.
+        /// </summary>
+        /// <param name="helpers">Dictionary of Handlebars helpers.</param>
+        public HbsBlockHelperService(
+            Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>> helpers)
+        {
+            Helpers = helpers;
+        }
+
+        /// <summary>
+        /// Register Handlebars block helpers.
+        /// </summary>
+        public void RegisterBlockHelpers()
+        {
+            foreach (var helper in Helpers)
+                HandlebarsDotNet.Handlebars.RegisterHelper(helper.Key,
+                    (output, options, context, args) => helper.Value(output, options, context, args));
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IHbsBlockHelperService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IHbsBlockHelperService.cs
@@ -1,0 +1,23 @@
+﻿using HandlebarsDotNet;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace EntityFrameworkCore.Scaffolding.Handlebars
+{
+    /// <summary>
+    /// Provide services required to register Handlebars block helpers.
+    /// </summary>
+    public interface IHbsBlockHelperService
+    {
+        /// <summary>
+        /// Handlebars block helpers.
+        /// </summary>
+        Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>> Helpers { get; }
+
+        /// <summary>
+        /// Register Handlebars block helpers.
+        /// </summary>
+        void RegisterBlockHelpers();
+    }
+}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
+using HandlebarsDotNet;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -107,6 +108,26 @@ namespace Microsoft.EntityFrameworkCore.Design
                 };
                 handlebarsHelpers.ToList().ForEach(h => helpers.Add(h.helperName, h.helperFunction));
                 return new HbsHelperService(helpers);
+            });
+            return services;
+        }
+
+        /// <summary>
+        /// Register Handlebars block helpers.
+        ///     <para>
+        ///         Note: You must first call AddHandlebarsScaffolding before calling AddHandlebarsHelpers.
+        ///     </para>        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="handlebarsBlockHelpers">Handlebars block helpers.</param>
+        /// <returns></returns>
+        public static IServiceCollection AddHandlebarsHelpers(this IServiceCollection services,
+            params (string helperName, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]> helperFunction)[] handlebarsBlockHelpers)
+        {
+            services.AddSingleton<IHbsBlockHelperService>(provider =>
+            {
+                var helpers = new Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>>();
+                handlebarsBlockHelpers.ToList().ForEach(h => helpers.Add(h.helperName, h.helperFunction));
+                return new HbsBlockHelperService(helpers);
             });
             return services;
         }


### PR DESCRIPTION
Following this [issue](https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/issues/70).
This would allow[ this kind of helpers](https://stackoverflow.com/a/47134327/15186) to be used in the templates.

