### PR TITLE
Fix unit tests after adding support for Handlebars block helpers.

### DIFF
--- a/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
+using HandlebarsDotNet;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
@@ -363,6 +364,8 @@ namespace Scaffolding.Handlebars.Tests
                 {
                     {EntityFrameworkCore.Scaffolding.Handlebars.Helpers.Constants.SpacesHelper, HandlebarsHelpers.SpacesHelper}
                 }))
+                .AddSingleton<IHbsBlockHelperService>(provider =>
+                new HbsBlockHelperService(new Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>>()))
                 .AddSingleton<IReverseEngineerScaffolder, HbsReverseEngineerScaffolder>();
 
             new SqlServerDesignTimeServices().ConfigureDesignTimeServices(services);

--- a/test/Scaffolding.Handlebars.Tests/HbsTypeScriptScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsTypeScriptScaffoldingGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
+using HandlebarsDotNet;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
@@ -347,6 +348,8 @@ namespace Scaffolding.Handlebars.Tests
                 {
                     {EntityFrameworkCore.Scaffolding.Handlebars.Helpers.Constants.SpacesHelper, HandlebarsHelpers.SpacesHelper}
                 }))
+                .AddSingleton<IHbsBlockHelperService>(provider =>
+                new HbsBlockHelperService(new Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>>()))
                 .AddSingleton<IReverseEngineerScaffolder, HbsReverseEngineerScaffolder>();
 
             new SqlServerDesignTimeServices().ConfigureDesignTimeServices(services);

--- a/test/Scaffolding.Handlebars.Tests/ReverseEngineeringConfigurationTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/ReverseEngineeringConfigurationTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
+using HandlebarsDotNet;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
@@ -49,6 +50,8 @@ namespace Scaffolding.Handlebars.Tests
                     {
                         {Constants.SpacesHelper, HandlebarsHelpers.SpacesHelper}
                     }))
+                .AddSingleton<IHbsBlockHelperService>(provider =>
+                    new HbsBlockHelperService(new Dictionary<string, Action<TextWriter, HelperOptions, Dictionary<string, object>, object[]>>()))
                .BuildServiceProvider()
                .GetRequiredService<IReverseEngineerScaffolder>();
 


### PR DESCRIPTION
Register `IHbsBlockHelperService` in unit tests.