### PR TITLE
Update HbsCSharpDbContextGenerator to emit transformed entityType.Name.

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -352,8 +352,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         {
             if (!_entityTypeBuilderInitialized)
             {
+                var transformedEntityName = EntityTypeTransformationService.TransformEntityName(entityType.Name);
+                
                 sb.AppendLine();
-                sb.AppendLine($"modelBuilder.Entity<{entityType.Name}>({EntityLambdaIdentifier} =>");
+                sb.AppendLine($"modelBuilder.Entity<{transformedEntityName}>({EntityLambdaIdentifier} =>");
                 sb.Append("{");
             }
 


### PR DESCRIPTION
Fix for issue where OnModelCreating is generating modelBuilder lines with the un-transformed EntityType names.