### PR TITLE
DataAnnotation: Usage of nameof in ForeignKeyAttribute/InversePropertyAttribute

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
@@ -3,7 +3,7 @@
 namespace {{namespace}}
 {
 {{#if class-annotation}}
-{{{class-annotation}}}
+{{spaces 4}}{{{class-annotation}}}
 {{/if}}
     public partial class {{class}}
     {

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -401,9 +401,16 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     var foreignKeyAttribute = new AttributeWriter(nameof(ForeignKeyAttribute));
 
-                    foreignKeyAttribute.AddParameter(
-                        CSharpHelper.Literal(
-                            string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
+                    if (navigation.ForeignKey.Properties.Count > 1)
+                    {
+                        foreignKeyAttribute.AddParameter(
+                                CSharpHelper.Literal(
+                                    string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
+                    }
+                    else
+                    { 
+                        foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
+                    }
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>
                     {
@@ -423,7 +430,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
 
-                    inversePropertyAttribute.AddParameter(CSharpHelper.Literal(inverseNavigation.Name));
+                    inversePropertyAttribute.AddParameter(
+                        !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
+                                m => m.Name == inverseNavigation.DeclaringEntityType.Name)
+                            ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
+                            : CSharpHelper.Literal(inverseNavigation.Name));
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>
                     {

--- a/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Class.hbs
@@ -3,7 +3,7 @@
 namespace {{namespace}}
 {
 {{#if class-annotation}}
-{{{class-annotation}}}
+{{spaces 4}}{{{class-annotation}}}
 {{/if}}
     public partial class {{class}}
     {

--- a/test/Scaffolding.Handlebars.Tests/EmbeddedResourceTemplateFileServiceTests.ExpectedTemplates.cs
+++ b/test/Scaffolding.Handlebars.Tests/EmbeddedResourceTemplateFileServiceTests.ExpectedTemplates.cs
@@ -33,7 +33,7 @@ namespace {{namespace}}
 namespace {{namespace}}
 {
 {{#if class-annotation}}
-{{{class-annotation}}}
+{{spaces 4}}{{{class-annotation}}}
 {{/if}}
     public partial class {{class}}
     {

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -96,7 +96,7 @@ namespace FakeNamespace
         public byte[] RowVersion { get; set; }
         public int? CategoryId { get; set; }
 
-        [ForeignKey(""CategoryId"")]
+        [ForeignKey(nameof(CategoryId))]
         [InverseProperty(""Product"")]
         public virtual Category Category { get; set; }
     }

--- a/test/Scaffolding.Handlebars.Tests/FileSystemTemplateFileServiceTests.ExpectedTemplates.cs
+++ b/test/Scaffolding.Handlebars.Tests/FileSystemTemplateFileServiceTests.ExpectedTemplates.cs
@@ -33,7 +33,7 @@ namespace {{namespace}}
 namespace {{namespace}}
 {
 {{#if class-annotation}}
-{{{class-annotation}}}
+{{spaces 4}}{{{class-annotation}}}
 {{/if}}
     public partial class {{class}}
     {


### PR DESCRIPTION
In this PR I did the followings (see issue #107):

- [x] GenerateForeignKeyAttribute now generates attribute using nameof when possible
- [x] GenerateInversePropertyAttribute now generates attribute using nameof when possible
- [x] TableAttribute is correctly formatted in class.hbs (tab was missing)
