### PR TITLE
Feature/supporting schema comments

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
@@ -2,9 +2,14 @@
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -2,7 +2,12 @@
 {{#each property-annotations}}
 {{spaces 8}}{{{property-annotation}}}
 {{/each}}
-{{spaces 8}}public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = default!;{{/unless}}{{/if}}
+{{#if property-comment}}
+{{spaces 8}}/// <summary>
+{{spaces 8}}/// {{property-comment}}
+{{spaces 8}}/// </summary>
+{{/if}}
+{{spaces 8}}public {{property-type}} {{property-name}} { get; set; }
 {{/each}}
 {{#if nav-properties}}
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Class.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Class.hbs
@@ -1,5 +1,10 @@
 ﻿{{> imports}}
 
+{{#if comment}}
+/**
+* {{comment}}
+*/
+{{/if}}
 export interface {{class}} {
-    {{{> properties}}}
+{{{> properties}}}
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -1,4 +1,9 @@
 ﻿{{#each properties}}
+{{#if property-comment}}
+{{spaces 4}}/**
+{{spaces 4}}* {{property-comment}}
+{{spaces 4}}*/
+{{/if}}
 {{spaces 4}}{{property-name}}: {{property-type}};
 {{/each}}
 {{#if nav-properties}}

--- a/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Class.hbs
@@ -2,9 +2,14 @@
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}

--- a/test/Scaffolding.Handlebars.Tests/Contexts/NorthwindDbContext.cs
+++ b/test/Scaffolding.Handlebars.Tests/Contexts/NorthwindDbContext.cs
@@ -14,6 +14,10 @@ namespace Scaffolding.Handlebars.Tests.Contexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Category>()
+                .HasComment("A category of products")
+                .Property(category => category.CategoryName)
+                    .HasComment("The name of a category");
         }
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/EmbeddedResourceTemplateFileServiceTests.ExpectedTemplates.cs
+++ b/test/Scaffolding.Handlebars.Tests/EmbeddedResourceTemplateFileServiceTests.ExpectedTemplates.cs
@@ -32,9 +32,14 @@ namespace {{namespace}}
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -34,9 +34,12 @@ namespace FakeNamespace
         {
             modelBuilder.Entity<Category>(entity =>
             {
+                entity.HasComment(""A category of products"");
+
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -94,6 +97,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Category>(entity =>
+            {
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
+            });
+
             modelBuilder.Entity<Product>(entity =>
             {
                 entity.HasIndex(e => e.CategoryId);
@@ -143,9 +153,12 @@ namespace FakeNamespace
             {
                 entity.ToTable(""Category"");
 
+                entity.HasComment(""A category of products"");
+
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -205,6 +218,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Category>(entity =>
+            {
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
+            });
+
             modelBuilder.Entity<Product>(entity =>
             {
                 entity.HasIndex(e => e.CategoryId);

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
@@ -34,9 +34,12 @@ namespace FakeNamespace
         {
             modelBuilder.Entity<Category>(entity =>
             {
+                entity.HasComment(""A category of products"");
+
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>

--- a/test/Scaffolding.Handlebars.Tests/FileSystemTemplateFileServiceTests.ExpectedTemplates.cs
+++ b/test/Scaffolding.Handlebars.Tests/FileSystemTemplateFileServiceTests.ExpectedTemplates.cs
@@ -32,9 +32,14 @@ namespace {{namespace}}
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}


### PR DESCRIPTION
**Proposed changes**
Two new handlebars tokens were added to allow for the use of {{comment}} on table templates and {{property-comment}} on property templates. This can be useful to incorporate database description metadata into XML doc comments on the models.

**Related Issue**
There isn't an associated issue at this time.

**Additional Resources**
Refer to the [Contributing Guidelines](https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/blob/master/.github/CONTRIBUTING.md) for this project.