### PR TITLE
Support for schema comments

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Class.hbs
@@ -2,9 +2,14 @@
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -1,4 +1,9 @@
 ﻿{{#each properties}}
+{{#if property-comment}}
+{{spaces 8}}/// <summary>
+{{spaces 8}}/// {{property-comment}}
+{{spaces 8}}/// </summary>
+{{/if}}
 {{#each property-annotations}}
 {{spaces 8}}{{{property-annotation}}}
 {{/each}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Class.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Class.hbs
@@ -1,5 +1,10 @@
 ﻿{{> imports}}
 
+{{#if comment}}
+/**
+* {{comment}}
+*/
+{{/if}}
 export interface {{class}} {
     {{{> properties}}}
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -1,4 +1,9 @@
 ﻿{{#each properties}}
+{{#if property-comment}}
+{{spaces 4}}/**
+{{spaces 4}}* {{property-comment}}
+{{spaces 4}}*/
+{{/if}}
 {{spaces 4}}{{property-name}}: {{property-type}};
 {{/each}}
 {{#if nav-properties}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -152,7 +152,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
 
             var transformedEntityName = EntityTypeTransformationService.TransformEntityName(entityType.Name);
-
+            
+            TemplateData.Add("comment", entityType.GetComment());
             TemplateData.Add("class", transformedEntityName);
 
             GenerateConstructor(entityType);
@@ -220,6 +221,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     { "property-type", propertyType },
                     { "property-name", property.Name },
                     { "property-annotations",  PropertyAnnotationsData },
+                    { "property-comment", property.GetComment() },
                     { "property-isnullable", property.IsNullable },
                     { "nullable-reference-types", _options?.Value?.EnableNullableReferenceTypes == true }
                 });

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
@@ -127,6 +127,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     { "property-type", transformedProp.PropertyType },
                     { "property-name", transformedProp.PropertyName },
                     { "property-annotations", property["property-annotations"] },
+                    { "property-comment", property["property-comment"] },
                     { "property-isnullable", transformedProp.PropertyIsNullable },
                     { "nullable-reference-types", property["nullable-reference-types"] }
                 });

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
@@ -125,6 +125,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var transformedEntityName = EntityTypeTransformationService.TransformEntityName(entityType.Name);
 
+            TemplateData.Add("comment", entityType.GetComment());
             TemplateData.Add("class", transformedEntityName);
 
             GenerateConstructor(entityType);
@@ -178,6 +179,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     { "property-type", TypeScriptHelper.TypeName(property.ClrType) },
                     { "property-name",  TypeScriptHelper.ToCamelCase(property.Name) },
                     { "property-annotations",  new List<Dictionary<string, object>>() },
+                    { "property-comment", property.GetComment() },
                     { "property-isnullable", property.IsNullable },
                     { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
                 });

--- a/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Class.hbs
@@ -2,9 +2,14 @@
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}

--- a/test/Scaffolding.Handlebars.Tests/Contexts/NorthwindDbContext.cs
+++ b/test/Scaffolding.Handlebars.Tests/Contexts/NorthwindDbContext.cs
@@ -14,6 +14,10 @@ namespace Scaffolding.Handlebars.Tests.Contexts
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Category>()
+                .HasComment("A category of products")
+                .Property(category => category.CategoryName)
+                    .HasComment("The name of a category");
         }
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/EmbeddedResourceTemplateFileServiceTests.ExpectedTemplates.cs
+++ b/test/Scaffolding.Handlebars.Tests/EmbeddedResourceTemplateFileServiceTests.ExpectedTemplates.cs
@@ -32,9 +32,14 @@ namespace {{namespace}}
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -34,9 +34,12 @@ namespace FakeNamespace
         {
             modelBuilder.Entity<Category>(entity =>
             {
+                entity.HasComment(""A category of products"");
+
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -94,6 +97,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Category>(entity =>
+            {
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
+            });
+
             modelBuilder.Entity<Product>(entity =>
             {
                 entity.HasIndex(e => e.CategoryId);
@@ -143,9 +153,12 @@ namespace FakeNamespace
             {
                 entity.ToTable(""Category"");
 
+                entity.HasComment(""A category of products"");
+
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -205,6 +218,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Category>(entity =>
+            {
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
+            });
+
             modelBuilder.Entity<Product>(entity =>
             {
                 entity.HasIndex(e => e.CategoryId);

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -10,6 +10,9 @@ using System.Collections.Generic;
 
 namespace FakeNamespace
 {
+    /// <summary>
+    /// A category of products
+    /// </summary>
     public partial class Category
     {
         public Category()
@@ -18,6 +21,9 @@ namespace FakeNamespace
         }
 
         public int CategoryId { get; set; }
+        /// <summary>
+        /// The name of a category
+        /// </summary>
         public string CategoryName { get; set; }
 
         public virtual ICollection<Product> Product { get; set; }
@@ -56,6 +62,9 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FakeNamespace
 {
+    /// <summary>
+    /// A category of products
+    /// </summary>
     public partial class Category
     {
         public Category()
@@ -65,6 +74,9 @@ namespace FakeNamespace
 
         [Key]
         public int CategoryId { get; set; }
+        /// <summary>
+        /// The name of a category
+        /// </summary>
         [Required]
         [StringLength(15)]
         public string CategoryName { get; set; }
@@ -112,6 +124,9 @@ using System.Collections.Generic;
 
 namespace FakeNamespace
 {
+    /// <summary>
+    /// A category of products
+    /// </summary>
     public partial class Category
     {
         public Category()
@@ -120,6 +135,9 @@ namespace FakeNamespace
         }
 
         public int CategoryId { get; set; }
+        /// <summary>
+        /// The name of a category
+        /// </summary>
         public string CategoryName { get; set; }
 
         public virtual ICollection<Product> Products { get; set; }
@@ -158,6 +176,9 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FakeNamespace
 {
+    /// <summary>
+    /// A category of products
+    /// </summary>
     [Table(""Category"")]
     public partial class Category
     {
@@ -168,6 +189,9 @@ namespace FakeNamespace
 
         [Key]
         public int CategoryId { get; set; }
+        /// <summary>
+        /// The name of a category
+        /// </summary>
         [Required]
         [StringLength(15)]
         public string CategoryName { get; set; }

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
@@ -34,9 +34,12 @@ namespace FakeNamespace
         {
             modelBuilder.Entity<Category>(entity =>
             {
+                entity.HasComment(""A category of products"");
+
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
-                    .HasMaxLength(15);
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptInterfaces.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptInterfaces.cs
@@ -7,8 +7,14 @@
             public const string CategoryClass =
 @"import { Product } from './Product';
 
+/**
+* A category of products
+*/
 export interface Category {
     categoryId: number;
+    /**
+    * The name of a category
+    */
     categoryName: string;
     product: Product[];
 }

--- a/test/Scaffolding.Handlebars.Tests/FileSystemTemplateFileServiceTests.ExpectedTemplates.cs
+++ b/test/Scaffolding.Handlebars.Tests/FileSystemTemplateFileServiceTests.ExpectedTemplates.cs
@@ -32,9 +32,14 @@ namespace {{namespace}}
 
 namespace {{namespace}}
 {
-{{#if class-annotation}}
-{{spaces 4}}{{{class-annotation}}}
-{{/if}}
+    {{#if comment}}
+    /// <summary>
+    /// {{comment}}
+    /// </summary>
+    {{/if}}
+    {{#if class-annotation}}
+    {{{class-annotation}}}
+    {{/if}}
     public partial class {{class}}
     {
         {{{> constructor}}}


### PR DESCRIPTION
**Proposed changes**
Two new handlebars tokens were added to allow for the use of {{comment}} on table templates and {{property-comment}} on property templates. This can be useful to incorporate database description metadata into XML doc comments on the models.

**Related Issue**
There isn't an associated issue at this time.