### PR TITLE
Handlebars Transformers Issues

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -623,7 +623,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         {
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.Property)}(e => e.{EntityTypeTransformationService.TransformPropertyName(property.Name)})"
+                $".{nameof(EntityTypeBuilder.Property)}(e => e.{EntityTypeTransformationService.TransformPropertyName(property.Name, property.DeclaringType.Name)})"
             };
 
             var annotations = property.GetAnnotations().ToList();
@@ -800,9 +800,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasOne)}(" + (foreignKey.DependentToPrincipal != null ? $"d => d.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.DependentToPrincipal.Name)}" : null) + ")",
+                $".{nameof(EntityTypeBuilder.HasOne)}(" + (foreignKey.DependentToPrincipal != null ? $"d => d.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.DependentToPrincipal.Name, foreignKey.PrincipalToDependent.DeclaringType.Name)}" : null) + ")",
                 $".{(foreignKey.IsUnique ? nameof(ReferenceNavigationBuilder.WithOne) : nameof(ReferenceNavigationBuilder.WithMany))}"
-                + $"(" + (foreignKey.PrincipalToDependent != null ? $"p => p.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.PrincipalToDependent.Name)}" : null) + ")"
+                + $"(" + (foreignKey.PrincipalToDependent != null ? $"p => p.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.PrincipalToDependent.Name, foreignKey.DependentToPrincipal.DeclaringType.Name)}" : null) + ")"
             };
 
             if (!foreignKey.PrincipalKey.IsPrimaryKey())
@@ -810,13 +810,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 canUseDataAnnotations = false;
                 lines.Add(
                     $".{nameof(ReferenceReferenceBuilder.HasPrincipalKey)}"
-                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.PrincipalEntityType).DisplayName())}>" : "")
+                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.PrincipalEntityType).DisplayName(), "")}>" : "")
                     + $"(p => {GenerateLambdaToKey(foreignKey.PrincipalKey.Properties, "p", EntityTypeTransformationService.TransformNavPropertyName)})");
             }
 
             lines.Add(
                 $".{nameof(ReferenceReferenceBuilder.HasForeignKey)}"
-                + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName())}>" : "")
+                + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformEntityName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName())}>" : "")
                 + $"(d => {GenerateLambdaToKey(foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
 
             var defaultOnDeleteAction = foreignKey.IsRequired
@@ -943,13 +943,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         private static string GenerateLambdaToKey(
             IReadOnlyList<IProperty> properties,
             string lambdaIdentifier,
-            Func<string, string> nameTransform)
+            Func<string, string, string> nameTransform)
         {
             return properties.Count <= 0
                 ? ""
                 : properties.Count == 1
-                ? $"{lambdaIdentifier}.{nameTransform(properties[0].Name)}"
-                : $"new {{ {string.Join(", ", properties.Select(p => lambdaIdentifier + "." + nameTransform(p.Name)))} }}";
+                ? $"{lambdaIdentifier}.{nameTransform(properties[0].Name, properties[0].DeclaringType.Name)}"
+                : $"new {{ {string.Join(", ", properties.Select(p => lambdaIdentifier + "." + nameTransform(p.Name, p.DeclaringType.Name)))} }}";
         }
 
         private static void RemoveAnnotation(ref List<IAnnotation> annotations, string annotationName)

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -502,7 +502,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasKey)}(e => {GenerateLambdaToKey(key.Properties, "e")})"
+                $".{nameof(EntityTypeBuilder.HasKey)}(e => {GenerateLambdaToKey(key.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
             };
 
             if (explicitName)
@@ -568,7 +568,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         {
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasIndex)}(e => {GenerateLambdaToKey(index.Properties, "e")})"
+                $".{nameof(EntityTypeBuilder.HasIndex)}(e => {GenerateLambdaToKey(index.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
             };
 
             var annotations = index.GetAnnotations().ToList();
@@ -623,7 +623,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         {
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.Property)}(e => e.{property.Name})"
+                $".{nameof(EntityTypeBuilder.Property)}(e => e.{EntityTypeTransformationService.TransformPropertyName(property.Name)})"
             };
 
             var annotations = property.GetAnnotations().ToList();
@@ -800,9 +800,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasOne)}(" + (foreignKey.DependentToPrincipal != null ? $"d => d.{foreignKey.DependentToPrincipal.Name}" : null) + ")",
+                $".{nameof(EntityTypeBuilder.HasOne)}(" + (foreignKey.DependentToPrincipal != null ? $"d => d.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.DependentToPrincipal.Name)}" : null) + ")",
                 $".{(foreignKey.IsUnique ? nameof(ReferenceNavigationBuilder.WithOne) : nameof(ReferenceNavigationBuilder.WithMany))}"
-                + $"(" + (foreignKey.PrincipalToDependent != null ? $"p => p.{foreignKey.PrincipalToDependent.Name}" : null) + ")"
+                + $"(" + (foreignKey.PrincipalToDependent != null ? $"p => p.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.PrincipalToDependent.Name)}" : null) + ")"
             };
 
             if (!foreignKey.PrincipalKey.IsPrimaryKey())
@@ -810,14 +810,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 canUseDataAnnotations = false;
                 lines.Add(
                     $".{nameof(ReferenceReferenceBuilder.HasPrincipalKey)}"
-                    + (foreignKey.IsUnique ? $"<{((ITypeBase)foreignKey.PrincipalEntityType).DisplayName()}>" : "")
-                    + $"(p => {GenerateLambdaToKey(foreignKey.PrincipalKey.Properties, "p")})");
+                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.PrincipalEntityType).DisplayName())}>" : "")
+                    + $"(p => {GenerateLambdaToKey(foreignKey.PrincipalKey.Properties, "p", EntityTypeTransformationService.TransformNavPropertyName)})");
             }
 
             lines.Add(
                 $".{nameof(ReferenceReferenceBuilder.HasForeignKey)}"
-                + (foreignKey.IsUnique ? $"<{((ITypeBase)foreignKey.DeclaringEntityType).DisplayName()}>" : "")
-                + $"(d => {GenerateLambdaToKey(foreignKey.Properties, "d")})");
+                + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName())}>" : "")
+                + $"(d => {GenerateLambdaToKey(foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
 
             var defaultOnDeleteAction = foreignKey.IsRequired
                 ? DeleteBehavior.Cascade
@@ -942,13 +942,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
         private static string GenerateLambdaToKey(
             IReadOnlyList<IProperty> properties,
-            string lambdaIdentifier)
+            string lambdaIdentifier,
+            Func<string, string> nameTransform)
         {
             return properties.Count <= 0
                 ? ""
                 : properties.Count == 1
-                ? $"{lambdaIdentifier}.{properties[0].Name}"
-                : $"new {{ {string.Join(", ", properties.Select(p => lambdaIdentifier + "." + p.Name))} }}";
+                ? $"{lambdaIdentifier}.{nameTransform(properties[0].Name)}"
+                : $"new {{ {string.Join(", ", properties.Select(p => lambdaIdentifier + "." + nameTransform(p.Name)))} }}";
         }
 
         private static void RemoveAnnotation(ref List<IAnnotation> annotations, string annotationName)

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -416,11 +416,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     {
                         foreignKeyAttribute.AddParameter(
                                 CSharpHelper.Literal(
-                                    string.Join(",", navigation.ForeignKey.Properties.Select(p => p.Name))));
+                                    string.Join(",", navigation.ForeignKey.Properties.Select(p => EntityTypeTransformationService.TransformNavPropertyName(p.Name, p.ClrType.Name)))));
                     }
                     else
-                    { 
-                        foreignKeyAttribute.AddParameter($"nameof({navigation.ForeignKey.Properties.First().Name})");
+                    {
+                        foreignKeyAttribute.AddParameter($"nameof({EntityTypeTransformationService.TransformNavPropertyName(navigation.ForeignKey.Properties.First().Name, navigation.ForeignKey.Properties.First().ClrType.Name)})");
                     }
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>
@@ -441,11 +441,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
 
+                    var propertyName = EntityTypeTransformationService.TransformNavPropertyName(inverseNavigation.Name, navigation.DeclaringType.Name);
                     inversePropertyAttribute.AddParameter(
                         !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
-                                m => m.Name == inverseNavigation.DeclaringEntityType.Name)
-                            ? $"nameof({inverseNavigation.DeclaringEntityType.Name}.{inverseNavigation.Name})"
-                            : CSharpHelper.Literal(inverseNavigation.Name));
+                                m => m.Name == inverseNavigation.DeclaringEntityType.Name ||
+                                    EntityTypeTransformationService.TransformNavPropertyName(m.Name, navigation.GetTargetType().Name) == EntityTypeTransformationService.TransformNavPropertyName(inverseNavigation.DeclaringEntityType.Name, navigation.GetTargetType().Name))
+                            ? $"nameof({EntityTypeTransformationService.TransformEntityName(inverseNavigation.DeclaringType.Name)}.{propertyName})"
+                            : CSharpHelper.Literal(propertyName));
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>
                     {

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
@@ -82,6 +82,17 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         }
 
         /// <summary>
+        /// Transform single navigation property name.
+        /// </summary>
+        /// <param name="propertyName">Property name.</param>
+        /// <returns>Transformed property name.</returns>
+        public string TransformNavPropertyName(string propertyName)
+        {
+            var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName };
+            return NavPropertyTransformer?.Invoke(propTypeInfo)?.PropertyName ?? propertyName;
+        }
+
+        /// <summary>
         /// Transform entity type constructor.
         /// </summary>
         /// <param name="lines">Constructor lines.</param>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
@@ -74,10 +74,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// Transform single property name.
         /// </summary>
         /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        public string TransformPropertyName(string propertyName)
+        public string TransformPropertyName(string propertyName, string propertyType)
         {
-            var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName };
+            var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName, PropertyType = propertyType };
             return PropertyTransformer?.Invoke(propTypeInfo)?.PropertyName ?? propertyName;
         }
 
@@ -85,10 +86,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// Transform single navigation property name.
         /// </summary>
         /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        public string TransformNavPropertyName(string propertyName)
+        public string TransformNavPropertyName(string propertyName, string propertyType)
         {
-            var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName };
+            var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName, PropertyType = propertyType };
             return NavPropertyTransformer?.Invoke(propTypeInfo)?.PropertyName ?? propertyName;
         }
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -29,6 +29,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         string TransformPropertyName(string propertyName);
 
         /// <summary>
+        /// Transform single navigation property name.
+        /// </summary>
+        /// <param name="propertyName">Property name.</param>
+        /// <returns>Transformed property name.</returns>
+        string TransformNavPropertyName(string propertyName);
+
+        /// <summary>
         /// Transform entity type constructor.
         /// </summary>
         /// <param name="lines">Constructor lines.</param>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -25,15 +25,17 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// Transform single property name.
         /// </summary>
         /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        string TransformPropertyName(string propertyName);
+        string TransformPropertyName(string propertyName, string propertyType);
 
         /// <summary>
         /// Transform single navigation property name.
         /// </summary>
         /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        string TransformNavPropertyName(string propertyName);
+        string TransformNavPropertyName(string propertyName, string propertyType);
 
         /// <summary>
         /// Transform entity type constructor.


### PR DESCRIPTION
This PR fix issue #98, includes all the fixes made by dmayhak and discussed in PR #102 including author requested changes, and completes it with some more fixes.

In order to reproduce the additional issues I've found, run the sample with the followings:

```c#
services.AddHandlebarsTransformers(
    entityNameTransformer: n => n == "CustomerSetting" ? "Setting" : n,
    entityFileNameTransformer: n => n,
    constructorTransformer: e => e.PropertyType == "CustomerSetting" ? new EntityPropertyInfo("Setting", e.PropertyName + "Foo") : e,
    propertyTransformer: e => e.PropertyName == "Setting" ? new EntityPropertyInfo(e.PropertyType, "Value") :
                                e.PropertyName == "Country" ? new EntityPropertyInfo("Country", e.PropertyName, false) : e,
    navPropertyTransformer: e => e.PropertyType == "CustomerSetting" ? new EntityPropertyInfo("Setting", e.PropertyName + "Foo") : e);
```

and execute the scaffold adding the DataAnnotation flag `-d`:

> dotnet ef dbcontext scaffold "Data Source=(localdb)\MSSQLLocalDB; Initial Catalog=NorthwindSlim; Integrated Security=True" Microsoft.EntityFrameworkCore.SqlServer -o Models -c NorthwindSlimContext -f --context-dir Contexts -d

I wanted to add some unit tests because at the present moment Transformers are not covered, but I didn't find the time yet.