### PR TITLE
EnableSchemaFolders with namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,6 @@ public class ScaffoldingDesignTimeServices : IDesignTimeServices
             // Enable Nullable reference types Support https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types
             options.EnableNullableReferenceTypes = true;
 
-            // Put Models into folders by DB Schema
-            //options.EnableSchemaFolders = true;
-
             // Exclude some tables
             options.ExcludedTables = new List<string> { "Territory", "EmployeeTerritories" };
 
@@ -180,7 +177,7 @@ public class ScaffoldingDesignTimeServices : IDesignTimeServices
                 { "base-class", "EntityBase" }
             };
 
-            // Place models in folders by schema
+            // Place models in folders by database schema
             //options.EnableSchemaFolders = true;
         });
 

--- a/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
@@ -28,9 +28,6 @@ namespace ScaffoldingSample
                 // Enable Nullable reference types Support https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types
                 options.EnableNullableReferenceTypes = true;
 
-                // Put Models into folders by DB Schema
-                //options.EnableSchemaFolders = true;
-
                 // Exclude some tables
                 options.ExcludedTables = new List<string> { "Territory", "EmployeeTerritories" };
 
@@ -41,7 +38,7 @@ namespace ScaffoldingSample
                     { "base-class", "EntityBase" }
                 };
 
-                // Place models in folders by schema
+                // Place models in folders by database schema
                 //options.EnableSchemaFolders = true;
             });
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EntityFrameworkCore.Scaffolding.Handlebars
 {
@@ -7,6 +8,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
     /// </summary>
     public interface IEntityTypeTransformationService
     {
+        /// <summary>
+        /// Transform entity type name
+        /// </summary>
+        /// <param name="entityType">Entity type</param>
+        /// <returns>Transformed entity type name.</returns>
+        string TransformEntityTypeName(IEntityType entityType);
+
         /// <summary>
         /// Transform entity type name.
         /// </summary>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
 using HandlebarsDotNet;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.EntityFrameworkCore.Design
@@ -197,21 +199,26 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="constructorTransformer"></param>
         /// <param name="propertyTransformer">Property name transformer.</param>
         /// <param name="navPropertyTransformer">Navigation property name transformer.</param>
+        /// <param name="entityTypeTransformer">Entity type name transformer.</param>
         /// <returns>The same service collection so that multiple calls can be chained.</returns>
         public static IServiceCollection AddHandlebarsTransformers(this IServiceCollection services,
             Func<string, string> entityNameTransformer = null,
             Func<string, string> entityFileNameTransformer = null,
             Func<EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
             Func<EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null)
+            Func<EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null,
+            Func<IEntityType, string> entityTypeTransformer = null)
         {
             services.AddSingleton<IEntityTypeTransformationService>(provider =>
                 new HbsEntityTypeTransformationService(
+                    provider.GetService<IOptions<HandlebarsScaffoldingOptions>>(),
+                    provider.GetService<ICSharpHelper>(),
                     entityNameTransformer,
                     entityFileNameTransformer,
                     constructorTransformer,
                     propertyTransformer,
-                    navPropertyTransformer));
+                    navPropertyTransformer,
+                    entityTypeTransformer));
             return services;
         }
     }


### PR DESCRIPTION
Added a new transformer `EntityTypeNameTransformer`. This is used to prefix the entity type name with the model namespace. Cleaned up documentation.

As the context namespace can differ from the model namespace I used a namespace alias called `Models` for referencing the entity types. The `EntityTypeNameTransformer` uses the `IEntityType` to get the schema and calls the `EntityNameTransformer` to get the entity name. Entities are then referenced as `Models.{Schema}.{TransformedEntityName}`.

Closes #119
