### PR TITLE
Fixed ExcludedTables option to also include views, as it did previously.

### DIFF
--- a/test/Scaffolding.Handlebars.Tests/IModelExtensionsTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/IModelExtensionsTests.cs
@@ -74,5 +74,45 @@ namespace Scaffolding.Handlebars.Tests
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
         }
+
+        [Fact]
+        public void IModel_Extensions_Should_Filter_EntityTypes_From_Options_By_View_Name_Only()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+            builder.Entity<Category>()
+                .ToView("Category", "dbo");
+
+            builder.Entity<Product>()
+                .ToView("Product", "prd");
+
+            var options = new HandlebarsScaffoldingOptions
+            {
+                ExcludedTables = new List<string> { "Product" }
+            };
+
+            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Product");
+        }
+
+        [Fact]
+        public void IModel_Extensions_Should_Filter_EntityTypes_From_Options_By_View_Name_and_Schema()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+            builder.Entity<Category>()
+                .ToView("Category", "dbo");
+
+            builder.Entity<Product>()
+                .ToView("Product", "prd");
+
+            var options = new HandlebarsScaffoldingOptions
+            {
+                ExcludedTables = new List<string> { "dbo.Category", "dbo.Product" }
+            };
+
+            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Category");
+            Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
+        }
     }
 }


### PR DESCRIPTION
**Describe your proposed changes**
With the .NET 5 updates, views were no longer being excluded using the ExcludedTables option.  I updated `IModelExtensions` to use GetViewName() and GetViewSchema() in addition to the table methods.

**Put `Closes #XXXX` in your comment**
Closes #149

**Additional Resources**

- [RelationalEntityTypeExtensions.GetViewName(IEntityType) Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.relationalentitytypeextensions.getviewname?view=efcore-5.0#Microsoft_EntityFrameworkCore_RelationalEntityTypeExtensions_GetViewName_Microsoft_EntityFrameworkCore_Metadata_IEntityType_)
- [RelationalEntityTypeExtensions.GetViewSchema(IEntityType) Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.relationalentitytypeextensions.getviewschema?view=efcore-5.0)