### PR TITLE
Fix issues associated with nullable navigation properties

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -19,7 +19,7 @@
 {{#if nav-property-collection}}
         public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
 {{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = default!;{{/unless}}{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -307,12 +307,25 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         GenerateNavigationDataAnnotations(navigation);
                     }
 
+                    var propertyIsNullable = !navigation.IsCollection && (
+                        navigation.IsOnDependent
+                        ? !navigation.ForeignKey.IsRequired
+                        : !navigation.ForeignKey.IsRequiredDependent
+                    );
+                    var navPropertyType = navigation.TargetEntityType.Name;
+                    if (_options?.Value?.EnableNullableReferenceTypes == true &&
+                        !navPropertyType.EndsWith("?") &&
+                        propertyIsNullable) {
+                        navPropertyType += "?";
+                    }
+
                     navProperties.Add(new Dictionary<string, object>
                     {
                         { "nav-property-collection", navigation.IsCollection },
-                        { "nav-property-type", navigation.TargetEntityType.Name },
+                        { "nav-property-type", navPropertyType },
                         { "nav-property-name", navigation.Name },
                         { "nav-property-annotations", NavPropertyAnnotations },
+                        { "nav-property-isnullable", propertyIsNullable },
                         { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
                     });
                 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
@@ -164,14 +164,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     navProperty["nav-property-name"] as string);
                 var transformedProp = NavPropertyTransformer?.Invoke(propTypeInfo) ?? propTypeInfo;
 
-                transformedNavProperties.Add(new Dictionary<string, object>
-                {
-                    { "nav-property-collection", navProperty["nav-property-collection"] },
-                    { "nav-property-type", transformedProp.PropertyType },
-                    { "nav-property-name", transformedProp.PropertyName },
-                    { "nav-property-annotations", navProperty["nav-property-annotations"] },
-                    { "nullable-reference-types", navProperty["nullable-reference-types"] }
-                });
+                var newNavProperty = new Dictionary<string, object>(navProperty);
+                newNavProperty["nav-property-type"] = transformedProp.PropertyType;
+                newNavProperty["nav-property-name"] = transformedProp.PropertyName;
+
+                transformedNavProperties.Add(newNavProperty);
             }
 
             return transformedNavProperties;

--- a/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/test/Scaffolding.Handlebars.Tests/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -18,7 +18,7 @@
 {{#if nav-property-collection}}
         public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
 {{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = default!;{{/unless}}{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -122,5 +122,56 @@ namespace FakeNamespace
 }
 ";
         }
+
+        private static class ExpectedEntitiesWithNullableNavigation
+        {
+            public const string CategoryClass =
+@"using System;
+using System.Collections.Generic;
+
+namespace FakeNamespace
+{
+    /// <summary>
+    /// A category of products
+    /// </summary>
+    public partial class Category
+    {
+        public Category()
+        {
+            Products = new HashSet<Product>();
+        }
+
+        public int CategoryId { get; set; } = default!;
+
+        /// <summary>
+        /// The name of a category
+        /// </summary>
+        public string CategoryName { get; set; } = default!;
+
+        public virtual ICollection<Product> Products { get; set; } = default!;
+    }
+}
+";
+
+            public const string ProductClass =
+@"using System;
+using System.Collections.Generic;
+
+namespace FakeNamespace
+{
+    public partial class Product
+    {
+        public int ProductId { get; set; } = default!;
+        public string ProductName { get; set; } = default!;
+        public decimal? UnitPrice { get; set; }
+        public bool Discontinued { get; set; } = default!;
+        public byte[]? RowVersion { get; set; }
+        public int? CategoryId { get; set; }
+
+        public virtual Category? Category { get; set; }
+    }
+}
+";
+        }
     }
 }


### PR DESCRIPTION
**Describe your proposed changes**
- Add an initially failing test for navigation properties that should be nullable
- Infer navigation property nullability from whether or not the association foreign key is required
- Extend the code generation in GenerateNavigationProperties to account for navigation property nullable
- Emit a nav-property-isnullable variable for use in Handlebars scripts

**Put `Closes #XXXX` in your comment**
Closes #151 

**Additional Resources**
Refer to the [Contributing Guidelines](https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/blob/master/.github/CONTRIBUTING.md) for this project.