### PR TITLE
Contains enhancements for the navigation properties

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using System.Collections.Generic;
 
 namespace EntityFrameworkCore.Scaffolding.Handlebars
 {
@@ -34,8 +35,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// </summary>
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyType">Property type</param>
+        /// <param name="navigation">EF Core navigation</param>
         /// <returns>Transformed property name.</returns>
-        string TransformNavPropertyName(string propertyName, string propertyType);
+        string TransformNavPropertyName(string propertyName, string propertyType, INavigation navigation);
 
         /// <summary>
         /// Transform entity type constructor.

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/NavigationPropertyInfo.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/NavigationPropertyInfo.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EntityFrameworkCore.Scaffolding.Handlebars
+{
+    /// <summary>
+    /// Navigation property info
+    /// </summary>
+    public class NavigationPropertyInfo: EntityPropertyInfo
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public NavigationPropertyInfo() { }
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="propertyType">Property type.</param>
+        /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyIsNullable">Property is nullable.</param>
+        /// <param name="navigation">EF Core navigation</param>
+        public NavigationPropertyInfo(string propertyType, string propertyName, bool propertyIsNullable = false, INavigation navigation = null)
+        {
+            PropertyType = propertyType;
+            PropertyName = propertyName;
+            PropertyIsNullable = propertyIsNullable;
+            NavigationDetails = navigation;
+        }
+
+
+        /// <summary>
+        /// EF Core Navigation details
+        /// </summary>
+        public INavigation NavigationDetails { get; set; }
+    }
+}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -200,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Design
             Func<string, string> entityFileNameTransformer = null,
             Func<EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
             Func<EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null,
+            Func<NavigationPropertyInfo, NavigationPropertyInfo> navPropertyTransformer = null,
             Func<string, string> contextFileNameTransformer = null)
         {
             services.AddSingleton<IEntityTypeTransformationService>(provider =>


### PR DESCRIPTION
Right now, when trying to filter navigation properties for transformation, we only have access to certain properties such as name, type and nullability.

This change is introducing a "NavigationPropertyInfo" class that derives from "EntityPropertyInfo". It contains an "INavigation Navigation" property so that users of the library will not be limited to certain properties of the original EF Core navigation. This will increase the extensibility of the project. It will also benefit the templating since users will have access to all properties of the navigation object.

Closes #160