### PR TITLE
fixed invalid schema when generating entity type names for views

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -284,7 +284,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 dbSets.Add(new Dictionary<string, object>
                 {
                     { "set-property-type", transformedEntityTypeName },
-                    { "set-property-name", !string.IsNullOrEmpty(entityType.GetTableName()) ? entityType.GetTableName() : entityType.GetViewName() },
+                    { "set-property-name", entityType.GetDbSetName() },
                     { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
                 });
             }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -284,7 +284,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 dbSets.Add(new Dictionary<string, object>
                 {
                     { "set-property-type", transformedEntityTypeName },
-                    { "set-property-name", entityType.GetDbSetName() },
+                    { "set-property-name", !string.IsNullOrEmpty(entityType.GetTableName()) ? entityType.GetTableName() : entityType.GetViewName() },
                     { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
                 });
             }
@@ -343,8 +343,12 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
         private string GetEntityTypeName(IEntityType entityType, string entityTypeName)
         {
+            var schema = !string.IsNullOrEmpty(entityType.GetTableName())
+                ? entityType.GetSchema()
+                : entityType.GetViewSchema();
+            
             return _options?.Value?.EnableSchemaFolders == true
-                ? $"{entityType.GetSchema()}.{entityTypeName}" : entityTypeName;
+                ? $"{schema}.{entityTypeName}" : entityTypeName;
         }
 
         private void GenerateEntityType(IEntityType entityType, bool useDataAnnotations, IndentedStringBuilder sb)

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -126,8 +126,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             GenerateImports(entityType);
 
             // TODO: _sb.AppendLine("#nullable disable");
+            var schema = !string.IsNullOrEmpty(entityType.GetTableName())
+                ? entityType.GetSchema()
+                : entityType.GetViewSchema();
             @namespace = _options?.Value?.EnableSchemaFolders == true
-                ? $"{@namespace}.{CSharpHelper.Namespace(entityType.GetSchema())}" : @namespace;
+                ? $"{@namespace}.{CSharpHelper.Namespace(schema)}" : @namespace;
 
             TemplateData.Add("namespace", @namespace);
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
@@ -149,8 +149,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         options.UseDataAnnotations);
 
                     var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.DisplayName());
+                    var schema = !string.IsNullOrEmpty(entityType.GetTableName())
+                        ? entityType.GetSchema()
+                        : entityType.GetViewSchema();
                     var entityTypeFileName = _options?.Value?.EnableSchemaFolders == true
-                        ? Path.Combine(CSharpHelper.Namespace(entityType.GetSchema()), transformedFileName + FileExtension)
+                        ? Path.Combine(CSharpHelper.Namespace(schema), transformedFileName + FileExtension)
                         : transformedFileName + FileExtension;
                     resultingFiles.AdditionalFiles.Add(
                         new ScaffoldedFile


### PR DESCRIPTION
**Describe your proposed changes**
The default `GetDbSetName()` method incorrectly gets a view's schema. The default schema is always returned for views.

**To reproduce error**
Create a view in a schema that is not the default and then generate entities with schema enabled.