### PR TITLE
EnableSchemaFolders Import/Qualification Fixes

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -714,7 +714,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             lines.Add(
                 $".{nameof(ReferenceReferenceBuilder.HasForeignKey)}"
-                + (foreignKey.IsUnique ? $"<{GetEntityTypeName(foreignKey.PrincipalEntityType, EntityTypeTransformationService.TransformTypeEntityName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName()))}>" : "")
+                + (foreignKey.IsUnique ? $"<{GetEntityTypeName(foreignKey.DeclaringEntityType, EntityTypeTransformationService.TransformTypeEntityName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName()))}>" : "")
                 + $"(d => {GenerateLambdaToKey(foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
 
             var defaultOnDeleteAction = foreignKey.IsRequired


### PR DESCRIPTION
This PR aims to fix issues surrounding namespaces/schemas when using the EnableSchemaFolders option.

Included fixes:
- Fixed usings that were required by navigation properties not being added to the entity type code.
- Fixed using the wrong namespace alias when generating fluent code for foreign keys between schemas.

Closes #134