### PR TITLE
Access IEntityType from transform functions

### DIFF
--- a/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
@@ -61,18 +61,25 @@ namespace ScaffoldingSample
 
             // Add Handlebars transformer for Country property
             services.AddHandlebarsTransformers(
-                propertyTransformer: e =>
-                    e.PropertyName == "Country"
-                        ? new EntityPropertyInfo("Country", e.PropertyName, false)
-                        : new EntityPropertyInfo(e.PropertyType, e.PropertyName, e.PropertyIsNullable));
+                propertyTransformer: (e, p) =>
+                    p.PropertyName == "Country"
+                        ? new EntityPropertyInfo("Country", p.PropertyName, false)
+                        : new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
+
+            // Add Handlebars transformer for Id property
+            //services.AddHandlebarsTransformers(
+            //    propertyTransformer: (e, p) =>
+            //        $"{e.Name}Id" == p.PropertyName
+            //            ? new EntityPropertyInfo(p.PropertyType, "Id", false)
+            //            : new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
 
             // Add optional Handlebars transformers
             //services.AddHandlebarsTransformers(
             //    entityNameTransformer: n => n + "Foo",
             //    entityFileNameTransformer: n => n + "Foo",
-            //    constructorTransformer: e => new EntityPropertyInfo(e.PropertyType + "Foo", e.PropertyName + "Foo"),
-            //    propertyTransformer: e => new EntityPropertyInfo(e.PropertyType, e.PropertyName + "Foo"),
-            //    navPropertyTransformer: e => new EntityPropertyInfo(e.PropertyType + "Foo", e.PropertyName + "Foo"));
+            //    constructorTransformer: (e, p) => new EntityPropertyInfo(p.PropertyType + "Foo", p.PropertyName + "Foo"),
+            //    propertyTransformer: (e, p) => new EntityPropertyInfo(p.PropertyType, p.PropertyName + "Foo"),
+            //    navPropertyTransformer: (e, p) => new EntityPropertyInfo(p.PropertyType + "Foo", p.PropertyName + "Foo"));
         }
 
         // Sample Handlebars helper

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -392,18 +392,18 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                 if (!useDataAnnotations || indexAnnotations.Count > 0)
                 {
-                    GenerateIndex(index, sb);
+                    GenerateIndex(entityType, index, sb);
                 }
             }
 
             foreach (var property in entityType.GetProperties())
             {
-                GenerateProperty(property, useDataAnnotations, sb);
+                GenerateProperty(entityType, property, useDataAnnotations, sb);
             }
 
             foreach (var foreignKey in entityType.GetScaffoldForeignKeys(_options.Value))
             {
-                GenerateRelationship(foreignKey, useDataAnnotations, sb);
+                GenerateRelationship(entityType, foreignKey, useDataAnnotations, sb);
             }
         }
 
@@ -478,7 +478,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasKey)}(e => {GenerateLambdaToKey(key.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
+                $".{nameof(EntityTypeBuilder.HasKey)}(e => {GenerateLambdaToKey(entityType, key.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
             };
 
             if (explicitName)
@@ -536,7 +536,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
         }
 
-        private void GenerateIndex(IIndex index, IndentedStringBuilder sb)
+        private void GenerateIndex(IEntityType entityType, IIndex index, IndentedStringBuilder sb)
         {
             var annotations = AnnotationCodeGenerator
                 .FilterIgnoredAnnotations(index.GetAnnotations())
@@ -545,7 +545,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasIndex)}(e => {GenerateLambdaToKey(index.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
+                $".{nameof(EntityTypeBuilder.HasIndex)}(e => {GenerateLambdaToKey(entityType, index.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
             };
             annotations.Remove(RelationalAnnotationNames.Name);
 
@@ -561,11 +561,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             AppendMultiLineFluentApi(index.DeclaringEntityType, lines, sb);
         }
 
-        private void GenerateProperty(IProperty property, bool useDataAnnotations, IndentedStringBuilder sb)
+        private void GenerateProperty(IEntityType entityType, IProperty property, bool useDataAnnotations, IndentedStringBuilder sb)
         {
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.Property)}(e => e.{EntityTypeTransformationService.TransformPropertyName(property.Name, property.DeclaringType.Name)})"
+                $".{nameof(EntityTypeBuilder.Property)}(e => e.{EntityTypeTransformationService.TransformPropertyName(entityType, property.Name, property.DeclaringType.Name)})"
             };
 
             var annotations = AnnotationCodeGenerator
@@ -684,7 +684,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             AppendMultiLineFluentApi(property.DeclaringEntityType, lines, sb);
         }
 
-        private void GenerateRelationship(IForeignKey foreignKey, bool useDataAnnotations, IndentedStringBuilder sb)
+        private void GenerateRelationship(IEntityType entityType, IForeignKey foreignKey, bool useDataAnnotations, IndentedStringBuilder sb)
         {
             var canUseDataAnnotations = true;
             var annotations = AnnotationCodeGenerator
@@ -695,11 +695,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             var lines = new List<string>
             {
                 $".{nameof(EntityTypeBuilder.HasOne)}("
-                + (foreignKey.DependentToPrincipal != null ? $"d => d.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.DependentToPrincipal?.Name, foreignKey.PrincipalToDependent?.DeclaringType.Name)}" : null)
+                + (foreignKey.DependentToPrincipal != null ? $"d => d.{EntityTypeTransformationService.TransformNavPropertyName(entityType, foreignKey.DependentToPrincipal?.Name, foreignKey.PrincipalToDependent?.DeclaringType.Name)}" : null)
                 + ")",
                 $".{(foreignKey.IsUnique ? nameof(ReferenceNavigationBuilder.WithOne) : nameof(ReferenceNavigationBuilder.WithMany))}"
                 + "("
-                + (foreignKey.PrincipalToDependent != null ? $"p => p.{EntityTypeTransformationService.TransformNavPropertyName(foreignKey.PrincipalToDependent?.Name, foreignKey.DependentToPrincipal?.DeclaringType.Name)}" : null)
+                + (foreignKey.PrincipalToDependent != null ? $"p => p.{EntityTypeTransformationService.TransformNavPropertyName(entityType, foreignKey.PrincipalToDependent?.Name, foreignKey.DependentToPrincipal?.DeclaringType.Name)}" : null)
                 + ")"
             };
 
@@ -708,14 +708,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 canUseDataAnnotations = false;
                 lines.Add(
                     $".{nameof(ReferenceReferenceBuilder.HasPrincipalKey)}"
-                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.PrincipalEntityType).DisplayName(), "")}>" : "")
-                    + $"(p => {GenerateLambdaToKey(foreignKey.PrincipalKey.Properties, "p", EntityTypeTransformationService.TransformNavPropertyName)})");
+                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(entityType, ((ITypeBase)foreignKey.PrincipalEntityType).DisplayName(), "")}>" : "")
+                    + $"(p => {GenerateLambdaToKey(entityType, foreignKey.PrincipalKey.Properties, "p", EntityTypeTransformationService.TransformNavPropertyName)})");
             }
 
             lines.Add(
                 $".{nameof(ReferenceReferenceBuilder.HasForeignKey)}"
                 + (foreignKey.IsUnique ? $"<{GetEntityTypeName(foreignKey.PrincipalEntityType, EntityTypeTransformationService.TransformTypeEntityName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName()))}>" : "")
-                + $"(d => {GenerateLambdaToKey(foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
+                + $"(d => {GenerateLambdaToKey(entityType, foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
 
             var defaultOnDeleteAction = foreignKey.IsRequired
                 ? DeleteBehavior.Cascade
@@ -854,15 +854,16 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         }
 
         private static string GenerateLambdaToKey(
+            IEntityType entityType,
             IReadOnlyList<IProperty> properties,
             string lambdaIdentifier,
-            Func<string, string, string> nameTransform)
+            Func<IEntityType, string, string, string> nameTransform)
         {
             return properties.Count <= 0
                 ? ""
                 : properties.Count == 1
-                ? $"{lambdaIdentifier}.{nameTransform(properties[0].Name, properties[0].DeclaringType.Name)}"
-                : $"new {{ {string.Join(", ", properties.Select(p => lambdaIdentifier + "." + nameTransform(p.Name, p.DeclaringType.Name)))} }}";
+                ? $"{lambdaIdentifier}.{nameTransform(entityType, properties[0].Name, properties[0].DeclaringType.Name)}"
+                : $"new {{ {string.Join(", ", properties.Select(p => lambdaIdentifier + "." + nameTransform(entityType, p.Name, p.DeclaringType.Name)))} }}";
         }
 
         private static void RemoveAnnotation(ref List<IAnnotation> annotations, string annotationName)

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -207,7 +207,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     });
                 }
 
-                var transformedLines = EntityTypeTransformationService.TransformConstructor(lines);
+                var transformedLines = EntityTypeTransformationService.TransformConstructor(entityType, lines);
 
                 TemplateData.Add("lines", transformedLines);
             }
@@ -249,7 +249,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 });
             }
 
-            var transformedProperties = EntityTypeTransformationService.TransformProperties(properties);
+            var transformedProperties = EntityTypeTransformationService.TransformProperties(entityType, properties);
 
             TemplateData.Add("properties", transformedProperties);
         }
@@ -304,7 +304,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                     if (UseDataAnnotations)
                     {
-                        GenerateNavigationDataAnnotations(navigation);
+                        GenerateNavigationDataAnnotations(entityType, navigation);
                     }
 
                     var propertyIsNullable = !navigation.IsCollection && (
@@ -330,7 +330,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     });
                 }
 
-                var transformedNavProperties = EntityTypeTransformationService.TransformNavigationProperties(navProperties);
+                var transformedNavProperties = EntityTypeTransformationService.TransformNavigationProperties(entityType, navProperties);
 
                 TemplateData.Add("nav-properties", transformedNavProperties);
             }
@@ -520,15 +520,15 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
         }
 
-        private void GenerateNavigationDataAnnotations(INavigation navigation)
+        private void GenerateNavigationDataAnnotations(IEntityType entityType, INavigation navigation)
         {
             if (navigation == null) throw new ArgumentNullException(nameof(navigation));
 
-            GenerateForeignKeyAttribute(navigation);
-            GenerateInversePropertyAttribute(navigation);
+            GenerateForeignKeyAttribute(entityType, navigation);
+            GenerateInversePropertyAttribute(entityType, navigation);
         }
 
-        private void GenerateForeignKeyAttribute(INavigation navigation)
+        private void GenerateForeignKeyAttribute(IEntityType entityType, INavigation navigation)
         {
             if (navigation.IsOnDependent)
             {
@@ -540,11 +540,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     {
                         foreignKeyAttribute.AddParameter(
                                 CSharpHelper.Literal(
-                                    string.Join(",", navigation.ForeignKey.Properties.Select(p => EntityTypeTransformationService.TransformNavPropertyName(p.Name, p.ClrType.Name)))));
+                                    string.Join(",", navigation.ForeignKey.Properties.Select(p => EntityTypeTransformationService.TransformNavPropertyName(entityType, p.Name, p.ClrType.Name)))));
                     }
                     else
                     {
-                        foreignKeyAttribute.AddParameter($"nameof({EntityTypeTransformationService.TransformNavPropertyName(navigation.ForeignKey.Properties.First().Name, navigation.ForeignKey.Properties.First().ClrType.Name)})");
+                        foreignKeyAttribute.AddParameter($"nameof({EntityTypeTransformationService.TransformNavPropertyName(entityType, navigation.ForeignKey.Properties.First().Name, navigation.ForeignKey.Properties.First().ClrType.Name)})");
                     }
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>
@@ -555,7 +555,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
         }
 
-        private void GenerateInversePropertyAttribute(INavigation navigation)
+        private void GenerateInversePropertyAttribute(IEntityType entityType, INavigation navigation)
         {
             if (navigation.ForeignKey.PrincipalKey.IsPrimaryKey())
             {
@@ -565,12 +565,12 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     var inversePropertyAttribute = new AttributeWriter(nameof(InversePropertyAttribute));
 
-                    var propertyName = EntityTypeTransformationService.TransformNavPropertyName(inverseNavigation.Name, navigation.DeclaringType.Name);
+                    var propertyName = EntityTypeTransformationService.TransformNavPropertyName(entityType, inverseNavigation.Name, navigation.DeclaringType.Name);
                     inversePropertyAttribute.AddParameter(
                         !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
                                 m => m.Name == inverseNavigation.DeclaringEntityType.Name ||
-                                    EntityTypeTransformationService.TransformNavPropertyName(m.Name, navigation.TargetEntityType.Name) 
-                                        == EntityTypeTransformationService.TransformNavPropertyName(inverseNavigation.DeclaringEntityType.Name, navigation.TargetEntityType.Name))
+                                    EntityTypeTransformationService.TransformNavPropertyName(entityType, m.Name, navigation.TargetEntityType.Name) 
+                                        == EntityTypeTransformationService.TransformNavPropertyName(entityType, inverseNavigation.DeclaringEntityType.Name, navigation.TargetEntityType.Name))
                             ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringType.Name)}.{propertyName})"
                             : CSharpHelper.Literal(propertyName));
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using System;
 using System.Collections.Generic;
 namespace EntityFrameworkCore.Scaffolding.Handlebars
 {
@@ -20,17 +21,17 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Constructor transformer.
         /// </summary>
-        public Func<EntityPropertyInfo, EntityPropertyInfo> ConstructorTransformer { get; }
+        public Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> ConstructorTransformer { get; }
 
         /// <summary>
         /// Property name transformer.
         /// </summary>
-        public Func<EntityPropertyInfo, EntityPropertyInfo> PropertyTransformer { get; }
+        public Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> PropertyTransformer { get; }
 
         /// <summary>
         /// Navigation property name transformer.
         /// </summary>
-        public Func<EntityPropertyInfo, EntityPropertyInfo> NavPropertyTransformer { get; }
+        public Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> NavPropertyTransformer { get; }
 
         /// <summary>
         /// HbsEntityTypeTransformationService constructor.
@@ -43,9 +44,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         public HbsEntityTypeTransformationService(
             Func<string, string> entityTypeNameTransformer = null,
             Func<string, string> entityFileNameTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null)
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null)
         {
             EntityTypeNameTransformer = entityTypeNameTransformer;
             EntityFileNameTransformer = entityFileNameTransformer;
@@ -73,33 +74,36 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Transform single property name.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        public string TransformPropertyName(string propertyName, string propertyType)
+        public string TransformPropertyName(IEntityType entityType, string propertyName, string propertyType)
         {
             var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName, PropertyType = propertyType };
-            return PropertyTransformer?.Invoke(propTypeInfo)?.PropertyName ?? propertyName;
+            return PropertyTransformer?.Invoke(entityType, propTypeInfo)?.PropertyName ?? propertyName;
         }
 
         /// <summary>
         /// Transform single navigation property name.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        public string TransformNavPropertyName(string propertyName, string propertyType)
+        public string TransformNavPropertyName(IEntityType entityType, string propertyName, string propertyType)
         {
             var propTypeInfo = new EntityPropertyInfo { PropertyName = propertyName, PropertyType = propertyType };
-            return NavPropertyTransformer?.Invoke(propTypeInfo)?.PropertyName ?? propertyName;
+            return NavPropertyTransformer?.Invoke(entityType, propTypeInfo)?.PropertyName ?? propertyName;
         }
 
         /// <summary>
         /// Transform entity type constructor.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="lines">Constructor lines.</param>
         /// <returns>Transformed constructor lines.</returns>
-        public List<Dictionary<string, object>> TransformConstructor(List<Dictionary<string, object>> lines)
+        public List<Dictionary<string, object>> TransformConstructor(IEntityType entityType, List<Dictionary<string, object>> lines)
         {
             var transformedLines = new List<Dictionary<string, object>>();
 
@@ -107,7 +111,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             {
                 var propTypeInfo = new EntityPropertyInfo(line["property-type"] as string,
                     line["property-name"] as string);
-                var transformedProp = ConstructorTransformer?.Invoke(propTypeInfo) ?? propTypeInfo;
+                var transformedProp = ConstructorTransformer?.Invoke(entityType, propTypeInfo) ?? propTypeInfo;
 
                 transformedLines.Add(new Dictionary<string, object>
                 {
@@ -122,9 +126,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Transform entity type properties.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="properties">Entity type properties.</param>
         /// <returns>Transformed entity type properties.</returns>
-        public List<Dictionary<string, object>> TransformProperties(List<Dictionary<string, object>> properties)
+        public List<Dictionary<string, object>> TransformProperties(IEntityType entityType, List<Dictionary<string, object>> properties)
         {
             var transformedProperties = new List<Dictionary<string, object>>();
 
@@ -133,7 +138,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 var propTypeInfo = new EntityPropertyInfo(property["property-type"] as string, 
                     property["property-name"] as string,
                     (property["property-isnullable"] as bool?) == true);
-                var transformedProp = PropertyTransformer?.Invoke(propTypeInfo) ?? propTypeInfo;
+                var transformedProp = PropertyTransformer?.Invoke(entityType, propTypeInfo) ?? propTypeInfo;
 
                 transformedProperties.Add(new Dictionary<string, object>
                 {
@@ -152,9 +157,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Transform entity type navigation properties.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="navProperties">Entity type navigation properties.</param>
         /// <returns>Transformed entity type navigation properties.</returns>
-        public List<Dictionary<string, object>> TransformNavigationProperties(List<Dictionary<string, object>> navProperties)
+        public List<Dictionary<string, object>> TransformNavigationProperties(IEntityType entityType, List<Dictionary<string, object>> navProperties)
         {
             var transformedNavProperties = new List<Dictionary<string, object>>();
 
@@ -162,7 +168,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             {
                 var propTypeInfo = new EntityPropertyInfo(navProperty["nav-property-type"] as string,
                     navProperty["nav-property-name"] as string);
-                var transformedProp = NavPropertyTransformer?.Invoke(propTypeInfo) ?? propTypeInfo;
+                var transformedProp = NavPropertyTransformer?.Invoke(entityType, propTypeInfo) ?? propTypeInfo;
 
                 var newNavProperty = new Dictionary<string, object>(navProperty);
                 newNavProperty["nav-property-type"] = transformedProp.PropertyType;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
@@ -158,7 +158,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     });
                 }
 
-                var transformedLines = EntityTypeTransformationService.TransformConstructor(lines);
+                var transformedLines = EntityTypeTransformationService.TransformConstructor(entityType, lines);
 
                 TemplateData.Add("lines", transformedLines);
             }
@@ -187,7 +187,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 });
             }
 
-            var transformedProperties = EntityTypeTransformationService.TransformProperties(properties);
+            var transformedProperties = EntityTypeTransformationService.TransformProperties(entityType, properties);
 
             TemplateData.Add("properties", transformedProperties);
         }
@@ -220,7 +220,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     });
                 }
 
-                var transformedNavProperties = EntityTypeTransformationService.TransformNavigationProperties(navProperties);
+                var transformedNavProperties = EntityTypeTransformationService.TransformNavigationProperties(entityType, navProperties);
 
                 TemplateData.Add("nav-properties", transformedNavProperties);
             }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using System.Collections.Generic;
 
 namespace EntityFrameworkCore.Scaffolding.Handlebars
 {
@@ -24,38 +25,43 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <summary>
         /// Transform single property name.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        string TransformPropertyName(string propertyName, string propertyType);
+        string TransformPropertyName(IEntityType entityType, string propertyName, string propertyType);
 
         /// <summary>
         /// Transform single navigation property name.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyType">Property type</param>
         /// <returns>Transformed property name.</returns>
-        string TransformNavPropertyName(string propertyName, string propertyType);
+        string TransformNavPropertyName(IEntityType entityType, string propertyName, string propertyType);
 
         /// <summary>
         /// Transform entity type constructor.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="lines">Constructor lines.</param>
         /// <returns>Transformed constructor lines.</returns>
-        List<Dictionary<string, object>> TransformConstructor(List<Dictionary<string, object>> lines);
+        List<Dictionary<string, object>> TransformConstructor(IEntityType entityType, List<Dictionary<string, object>> lines);
 
         /// <summary>
         /// Transform entity type properties.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="properties">Entity type properties.</param>
         /// <returns>Transformed entity type properties.</returns>
-        List<Dictionary<string, object>> TransformProperties(List<Dictionary<string, object>> properties);
+        List<Dictionary<string, object>> TransformProperties(IEntityType entityType, List<Dictionary<string, object>> properties);
 
         /// <summary>
         /// Transform entity type navigation properties.
         /// </summary>
+        /// <param name="entityType">Entity type.</param>
         /// <param name="navProperties">Entity type navigation properties.</param>
         /// <returns>Transformed entity type navigation properties.</returns>
-        List<Dictionary<string, object>> TransformNavigationProperties(List<Dictionary<string, object>> navProperties);
+        List<Dictionary<string, object>> TransformNavigationProperties(IEntityType entityType, List<Dictionary<string, object>> navProperties);
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
 using HandlebarsDotNet;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.Extensions.DependencyInjection;
@@ -198,9 +199,9 @@ namespace Microsoft.EntityFrameworkCore.Design
         public static IServiceCollection AddHandlebarsTransformers(this IServiceCollection services,
             Func<string, string> entityNameTransformer = null,
             Func<string, string> entityFileNameTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
-            Func<EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null,
             Func<string, string> contextFileNameTransformer = null)
         {
             services.AddSingleton<IEntityTypeTransformationService>(provider =>


### PR DESCRIPTION
This PR allows access to entity type from transform functions.
Example of use : rename all primary keys ‘TableNameId’ to ‘Id’
`
services.AddHandlebarsTransformers(propertyTransformer: (e, p) => 
$"{e.Name}Id" == p.PropertyName ? 
new EntityPropertyInfo(p.PropertyType, "Id", false) : 
new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
`