### PR TITLE
Update to EF Core 6

### DIFF
--- a/sample/ScaffoldingSample.Api/ScaffoldingSample.Api.csproj
+++ b/sample/ScaffoldingSample.Api/ScaffoldingSample.Api.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/ScaffoldingSample.Embedded/ScaffoldingSample.Embedded.csproj
+++ b/sample/ScaffoldingSample.Embedded/ScaffoldingSample.Embedded.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -15,3 +15,12 @@
 {{/if}}
 {{/each}}
 {{/if}}
+{{#if skip-nav-properties}}
+{{#each skip-nav-properties}}
+{{#if nav-property-collection}}
+    {{nav-property-name}}: {{nav-property-type}}[];
+{{else}}
+    {{nav-property-name}}: {{nav-property-type}};
+{{/if}}
+{{/each}}
+{{/if}}

--- a/sample/ScaffoldingSample.TypeScript/ScaffoldingSample.TypeScript.csproj
+++ b/sample/ScaffoldingSample.TypeScript/ScaffoldingSample.TypeScript.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/ScaffoldingSample/CodeTemplates/CSharpDbContext/Partials/DbSets.hbs
+++ b/sample/ScaffoldingSample/CodeTemplates/CSharpDbContext/Partials/DbSets.hbs
@@ -1,4 +1,4 @@
 ﻿{{#each dbsets}}
         {{my-helper}}
-        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = default!;{{/if}}
+        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = null!;{{/if}}
 {{/each}}

--- a/sample/ScaffoldingSample/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/sample/ScaffoldingSample/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -8,7 +8,7 @@
 {{#each property-annotations}}
         {{{property-annotation}}}
 {{/each}}
-        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = default!;{{/unless}}{{/if}}
+        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = null!;{{/unless}}{{/if}}
 {{/each}}
 {{#if nav-properties}}
 
@@ -17,9 +17,22 @@
         {{{nav-property-annotation}}}
 {{/each}}
 {{#if nav-property-collection}}
-        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
+        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
 {{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = default!;{{/unless}}{{/if}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{#if skip-nav-properties}}
+
+{{#each skip-nav-properties}}
+{{#each nav-property-annotations}}
+        {{{nav-property-annotation}}}
+{{/each}}
+{{#if nav-property-collection}}
+        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
+{{else}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
@@ -27,9 +27,6 @@ namespace ScaffoldingSample
                 // Generate both context and entities
                 options.ReverseEngineerOptions = ReverseEngineerOptions.DbContextAndEntities;
 
-                // Enable Nullable reference types Support https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types
-                options.EnableNullableReferenceTypes = true;
-
                 // Put Models into folders by DB Schema
                 options.EnableSchemaFolders = true;
 

--- a/sample/ScaffoldingSample/ScaffoldingSample.csproj
+++ b/sample/ScaffoldingSample/ScaffoldingSample.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/TemplatesAssembly/CodeTemplates/CSharpDbContext/Partials/DbSets.hbs
+++ b/sample/TemplatesAssembly/CodeTemplates/CSharpDbContext/Partials/DbSets.hbs
@@ -1,3 +1,3 @@
 ﻿{{#each dbsets}}
-        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = default!;{{/if}}
+        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = null!;{{/if}}
 {{/each}}

--- a/sample/TemplatesAssembly/CodeTemplates/CSharpEntityType/Class.hbs
+++ b/sample/TemplatesAssembly/CodeTemplates/CSharpEntityType/Class.hbs
@@ -4,7 +4,7 @@ namespace {{namespace}}
 {
     {{#if comment}}
     /// <summary>
-    /// {{comment}}
+{{comment}}
     /// </summary>
     {{/if}}
     {{#each class-annotations}}

--- a/sample/TemplatesAssembly/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/sample/TemplatesAssembly/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -1,13 +1,14 @@
 ﻿{{#each properties}}
 {{#if property-comment}}
+
         /// <summary>
-        /// {{property-comment}}
+{{property-comment}}
         /// </summary>
 {{/if}}
 {{#each property-annotations}}
         {{{property-annotation}}}
 {{/each}}
-        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = default!;{{/unless}}{{/if}}
+        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = null!;{{/unless}}{{/if}}
 {{/each}}
 {{#if nav-properties}}
 
@@ -16,9 +17,22 @@
         {{{nav-property-annotation}}}
 {{/each}}
 {{#if nav-property-collection}}
-        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
+        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
 {{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}
+{{#if skip-nav-properties}}
+
+{{#each skip-nav-properties}}
+{{#each nav-property-annotations}}
+        {{{nav-property-annotation}}}
+{{/each}}
+{{#if nav-property-collection}}
+        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
+{{else}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/sample/TemplatesAssembly/CodeTemplates/TypeScriptDbContext/DbContext.hbs
+++ b/sample/TemplatesAssembly/CodeTemplates/TypeScriptDbContext/DbContext.hbs
@@ -7,7 +7,7 @@ namespace {{namespace}}
 {{{> dbsets}}}
 {{#if entity-type-errors}}
 {{#each entity-type-errors}}
-        {{{entity-type-error}}}
+{{{entity-type-error}}}
 {{/each}}
 
 {{/if}}

--- a/sample/TemplatesAssembly/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/sample/TemplatesAssembly/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -15,3 +15,12 @@
 {{/if}}
 {{/each}}
 {{/if}}
+{{#if skip-nav-properties}}
+{{#each skip-nav-properties}}
+{{#if nav-property-collection}}
+    {{nav-property-name}}: {{nav-property-type}}[];
+{{else}}
+    {{nav-property-name}}: {{nav-property-type}};
+{{/if}}
+{{/each}}
+{{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpDbContext/Partials/DbSets.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpDbContext/Partials/DbSets.hbs
@@ -1,3 +1,3 @@
 ﻿{{#each dbsets}}
-        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = default!;{{/if}}
+        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = null!;{{/if}}
 {{/each}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -8,7 +8,7 @@
 {{#each property-annotations}}
         {{{property-annotation}}}
 {{/each}}
-        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = default!;{{/unless}}{{/if}}
+        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = null!;{{/unless}}{{/if}}
 {{/each}}
 {{#if nav-properties}}
 
@@ -17,9 +17,9 @@
         {{{nav-property-annotation}}}
 {{/each}}
 {{#if nav-property-collection}}
-        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }{{#if nullable-reference-types}} = default!;{{/if}}
+        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
 {{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = default!;{{/unless}}{{/if}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
 {{/if}}
 {{/each}}
 {{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -23,3 +23,16 @@
 {{/if}}
 {{/each}}
 {{/if}}
+{{#if skip-nav-properties}}
+
+{{#each skip-nav-properties}}
+{{#each nav-property-annotations}}
+        {{{nav-property-annotation}}}
+{{/each}}
+{{#if nav-property-collection}}
+        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
+{{else}}
+        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
+{{/if}}
+{{/each}}
+{{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -15,3 +15,12 @@
 {{/if}}
 {{/each}}
 {{/if}}
+{{#if skip-nav-properties}}
+{{#each skip-nav-properties}}
+{{#if nav-property-collection}}
+    {{nav-property-name}}: {{nav-property-type}}[];
+{{else}}
+    {{nav-property-name}}: {{nav-property-type}};
+{{/if}}
+{{/each}}
+{{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>5.0.5-preview1</Version>
+    <Version>6.0.0-preview1</Version>
     <Authors>Tony Sneed</Authors>
     <Company>Tony Sneed</Company>
     <Title>Entity Framework Core Scaffolding with Handlebars</Title>
@@ -17,8 +17,8 @@
     <IncludeSource>true</IncludeSource>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
-    <AssemblyVersion>5.0.0.0</AssemblyVersion>
-    <FileVersion>5.0.0.0</FileVersion>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>
+    <FileVersion>6.0.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -58,8 +58,10 @@
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="2.0.9" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -22,11 +22,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.1\EntityFrameworkCore.Scaffolding.Handlebars.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\net6.0\EntityFrameworkCore.Scaffolding.Handlebars.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.1\EntityFrameworkCore.Scaffolding.Handlebars.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\net6.0\EntityFrameworkCore.Scaffolding.Handlebars.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,26 +35,26 @@
 
   <ItemGroup>
     <!-- pack  template files -->
-    <Content Include="CodeTemplates\CSharpDbContext\DbContext.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpDbContext\" />
-    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbImports.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpDbContext\Partials\" />
-    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbConstructor.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpDbContext\Partials\" />
-    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbOnConfiguring.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpDbContext\Partials\" />
-    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbSets.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpDbContext\Partials\" />
-    <Content Include="CodeTemplates\CSharpEntityType\Class.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpEntityType\" />
-    <Content Include="CodeTemplates\CSharpEntityType\Partials\Constructor.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpEntityType\Partials\" />
-    <Content Include="CodeTemplates\CSharpEntityType\Partials\Imports.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpEntityType\Partials\" />
-    <Content Include="CodeTemplates\CSharpEntityType\Partials\Properties.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\CSharpEntityType\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptDbContext\DbContext.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptDbContext\" />
-    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbImports.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptDbContext\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbConstructor.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptDbContext\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbOnConfiguring.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptDbContext\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbSets.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptDbContext\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptEntityType\Class.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptEntityType\" />
-    <Content Include="CodeTemplates\TypeScriptEntityType\Partials\Constructor.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptEntityType\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptEntityType\Partials\Imports.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptEntityType\Partials\" />
-    <Content Include="CodeTemplates\TypeScriptEntityType\Partials\Properties.hbs" PackagePath="lib\netstandard2.1\CodeTemplates\TypeScriptEntityType\Partials\" />
+    <Content Include="CodeTemplates\CSharpDbContext\DbContext.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpDbContext\" />
+    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbImports.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpDbContext\Partials\" />
+    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbConstructor.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpDbContext\Partials\" />
+    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbOnConfiguring.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpDbContext\Partials\" />
+    <Content Include="CodeTemplates\CSharpDbContext\Partials\DbSets.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpDbContext\Partials\" />
+    <Content Include="CodeTemplates\CSharpEntityType\Class.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpEntityType\" />
+    <Content Include="CodeTemplates\CSharpEntityType\Partials\Constructor.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpEntityType\Partials\" />
+    <Content Include="CodeTemplates\CSharpEntityType\Partials\Imports.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpEntityType\Partials\" />
+    <Content Include="CodeTemplates\CSharpEntityType\Partials\Properties.hbs" PackagePath="lib\net6.0\CodeTemplates\CSharpEntityType\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptDbContext\DbContext.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptDbContext\" />
+    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbImports.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptDbContext\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbConstructor.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptDbContext\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbOnConfiguring.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptDbContext\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptDbContext\Partials\DbSets.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptDbContext\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptEntityType\Class.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptEntityType\" />
+    <Content Include="CodeTemplates\TypeScriptEntityType\Partials\Constructor.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptEntityType\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptEntityType\Partials\Imports.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptEntityType\Partials\" />
+    <Content Include="CodeTemplates\TypeScriptEntityType\Partials\Properties.hbs" PackagePath="lib\net6.0\CodeTemplates\TypeScriptEntityType\Partials\" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Handlebars.Net" Version="2.0.9" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -59,9 +59,7 @@
     <PackageReference Include="Handlebars.Net" Version="2.0.9" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HandlebarsScaffoldingOptions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HandlebarsScaffoldingOptions.cs
@@ -26,7 +26,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         public LanguageOptions LanguageOptions { get; set; }
 
         /// <summary>
-        /// Gets or sets tables that should be excluded from; can include schema. 
+        /// Gets or sets tables that should be excluded from; can include schema.
         /// </summary>
         public List<string> ExcludedTables { get; set; }
 
@@ -37,7 +37,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
         /// <summary>
         /// Gets or sets an assembly to read embedded templates from (optional).
-        /// </summary>  
+        /// </summary>
         public Assembly EmbeddedTemplatesAssembly { get; set; }
 
         /// <summary>
@@ -49,13 +49,6 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// Gets or sets if schema folders are created for table entity classes as per db schema naming.
         /// </summary>
         public bool EnableSchemaFolders { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether entity properties are declared and instantiated in the C# 8.0+ nullable reference types style (optional).
-        /// https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
-        /// https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types
-        /// </summary>
-        public bool EnableNullableReferenceTypes { get; set; }
 
         /// <summary>
         /// Gets or sets whether table and column descriptions generate XML comments.

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -637,17 +637,19 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     $".{nameof(PropertyBuilder.IsUnicode)}({(property.IsUnicode() == false ? "false" : "")})");
             }
 
-            var defaultValue = property.GetDefaultValue();
-            if (defaultValue == DBNull.Value)
+            if (property.TryGetDefaultValue(out var defaultValue))
             {
-                lines.Add($".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}()");
-                annotations.Remove(RelationalAnnotationNames.DefaultValue);
-            }
-            else if (defaultValue != null)
-            {
-                lines.Add(
-                    $".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}({CSharpHelper.UnknownLiteral(defaultValue)})");
-                annotations.Remove(RelationalAnnotationNames.DefaultValue);
+                if (defaultValue == DBNull.Value)
+                {
+                    lines.Add($".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}()");
+                    annotations.Remove(RelationalAnnotationNames.DefaultValue);
+                }
+                else if (defaultValue != null)
+                {
+                    lines.Add(
+                        $".{nameof(RelationalPropertyBuilderExtensions.HasDefaultValue)}({CSharpHelper.UnknownLiteral(defaultValue)})");
+                    annotations.Remove(RelationalAnnotationNames.DefaultValue);
+                }
             }
 
             var valueGenerated = property.ValueGenerated;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -744,13 +744,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 canUseDataAnnotations = false;
                 lines.Add(
                     $".{nameof(ReferenceReferenceBuilder.HasPrincipalKey)}"
-                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(((ITypeBase)foreignKey.PrincipalEntityType).DisplayName(), "")}>" : "")
+                    + (foreignKey.IsUnique ? $"<{EntityTypeTransformationService.TransformPropertyName(foreignKey.PrincipalEntityType.Name, "")}>" : "")
                     + $"(p => {GenerateLambdaToKey(foreignKey.PrincipalKey.Properties, "p", EntityTypeTransformationService.TransformNavPropertyName)})");
             }
 
             lines.Add(
                 $".{nameof(ReferenceReferenceBuilder.HasForeignKey)}"
-                + (foreignKey.IsUnique ? $"<{GetEntityTypeName(foreignKey.DeclaringEntityType, EntityTypeTransformationService.TransformTypeEntityName(((ITypeBase)foreignKey.DeclaringEntityType).DisplayName()))}>" : "")
+                + (foreignKey.IsUnique ? $"<{GetEntityTypeName(foreignKey.DeclaringEntityType, EntityTypeTransformationService.TransformTypeEntityName(foreignKey.DeclaringEntityType.Name))}>" : "")
                 + $"(d => {GenerateLambdaToKey(foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
 
             var defaultOnDeleteAction = foreignKey.IsRequired
@@ -828,7 +828,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                                 lines.Add($".{nameof(RelationalKeyBuilderExtensions.HasName)}({CSharpHelper.Literal(key.GetName()!)})");
                             }
 
-                            GenerateAnnotations(keyAnnotations.Values);
+                            lines.AddRange(
+                                AnnotationCodeGenerator.GenerateFluentApiCalls(key, keyAnnotations).Select(m => CSharpHelper.Fragment(m))
+                                    .Concat(GenerateAnnotations(keyAnnotations.Values)));
+
                             WriteLines(";");
 
                             var annotations = AnnotationCodeGenerator
@@ -856,7 +859,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                             lines.Add($"j.{nameof(RelationalEntityTypeBuilderExtensions.ToTable)}({parameterString})");
 
-                            GenerateAnnotations(annotations.Values);
+                            lines.AddRange(
+                                AnnotationCodeGenerator.GenerateFluentApiCalls(joinEntityType, annotations).Select(m => CSharpHelper.Fragment(m))
+                                    .Concat(GenerateAnnotations(annotations.Values)));
 
                             sb.AppendLine();
                             WriteLines(";");
@@ -879,7 +884,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                                     lines.Add($".{nameof(IndexBuilder.IsUnique)}()");
                                 }
 
-                                GenerateAnnotations(indexAnnotations.Values);
+                                lines.AddRange(
+                                    AnnotationCodeGenerator.GenerateFluentApiCalls(index, indexAnnotations).Select(m => CSharpHelper.Fragment(m))
+                                        .Concat(GenerateAnnotations(indexAnnotations.Values)));
 
                                 sb.AppendLine();
                                 WriteLines(";");
@@ -981,7 +988,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                                     lines.Add($".{nameof(PropertyBuilder.IsConcurrencyToken)}()");
                                 }
 
-                                GenerateAnnotations(propertyAnnotations.Values);
+                                lines.AddRange(
+                                    AnnotationCodeGenerator.GenerateFluentApiCalls(property, propertyAnnotations).Select(m => CSharpHelper.Fragment(m))
+                                        .Concat(GenerateAnnotations(propertyAnnotations.Values)));
 
                                 if (lines.Count > 1)
                                 {
@@ -1024,7 +1033,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                                 lines.Add($".{nameof(ReferenceReferenceBuilder.OnDelete)}({CSharpHelper.Literal(foreignKey.DeleteBehavior)})");
                             }
 
-                            GenerateAnnotations(annotations.Values);
+                            lines.AddRange(
+                                AnnotationCodeGenerator.GenerateFluentApiCalls(foreignKey, annotations).Select(m => CSharpHelper.Fragment(m))
+                                    .Concat(GenerateAnnotations(annotations.Values)));
                             WriteLines(",");
                         }
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -63,8 +63,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// </summary>
         protected Dictionary<string, object> TemplateData { get; set; }
 
+        /// <summary>
+        /// Indicates if data annotations should be used.
+        /// </summary>
         protected bool UseDataAnnotations { get; set; }
 
+        /// <summary>
+        /// Indicates if nullable reference types should be used.
+        /// </summary>
         protected bool UseNullableReferenceTypes { get; set; }
 
         private bool _entityTypeBuilderInitialized;
@@ -79,7 +85,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="entityTypeTransformationService">Service for transforming entity definitions.</param>
         /// <param name="options">Handlebars scaffolding options.</param>
         public HbsCSharpDbContextGenerator(
-            [NotNull] IProviderConfigurationCodeGenerator providerConfigurationCodeGenerator, 
+            [NotNull] IProviderConfigurationCodeGenerator providerConfigurationCodeGenerator,
             [NotNull] IAnnotationCodeGenerator annotationCodeGenerator,
             [NotNull] IDbContextTemplateService dbContextTemplateService,
             [NotNull] IEntityTypeTransformationService entityTypeTransformationService,
@@ -290,7 +296,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     { "set-property-type", transformedEntityTypeName },
                     { "set-property-name", entityType.GetDbSetName() },
-                    { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
+                    { "nullable-reference-types", UseNullableReferenceTypes }
                 });
             }
 
@@ -351,7 +357,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             var schema = !string.IsNullOrEmpty(entityType.GetTableName())
                 ? entityType.GetSchema()
                 : entityType.GetViewSchema();
-            
+
             return _options?.Value?.EnableSchemaFolders == true
                 ? $"{schema}.{entityTypeName}" : entityTypeName;
         }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -601,7 +601,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
             else
             {
-                if (!property.IsNullable
+                if ((!UseNullableReferenceTypes || property.ClrType.IsValueType)
+                    && !property.IsNullable
                     && property.ClrType.IsNullableType()
                     && !property.IsPrimaryKey())
                 {

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -560,7 +560,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var lines = new List<string>
             {
-                $".{nameof(EntityTypeBuilder.HasIndex)}(e => {GenerateLambdaToKey(index.Properties, "e", EntityTypeTransformationService.TransformPropertyName)})"
+                $".{nameof(EntityTypeBuilder.HasIndex)}(e => {GenerateLambdaToKey(index.Properties, "e", EntityTypeTransformationService.TransformPropertyName)}, {CSharpHelper.Literal(index.GetDatabaseName())})"
             };
             annotations.Remove(RelationalAnnotationNames.Name);
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -264,13 +264,16 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     && !propertyType.EndsWith("?")) {
                         propertyType += "?";
                 }
+                var propertyIsNullable = property.ClrType.IsValueType
+                    || (UseNullableReferenceTypes
+                     && property.IsNullable);
                 properties.Add(new Dictionary<string, object>
                 {
                     { "property-type", propertyType },
                     { "property-name", property.Name },
                     { "property-annotations",  PropertyAnnotationsData },
                     { "property-comment", _options?.Value?.GenerateComments == true ? GenerateComment(property.GetComment(), 2) : null },
-                    { "property-isnullable", property.IsNullable },
+                    { "property-isnullable", propertyIsNullable },
                     { "nullable-reference-types", UseNullableReferenceTypes }
                 });
             }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -112,7 +112,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="useDataAnnotations">If true use data annotations.</param>
         /// <param name="useNullableReferenceTypes">If true use nullable reference types.</param>
         /// <returns>Generated entity type.</returns>
-        public override string WriteCode(IEntityType entityType, string? @namespace, bool useDataAnnotations, bool useNullableReferenceTypes)
+        public override string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations, bool useNullableReferenceTypes)
         {
             Check.NotNull(entityType, nameof(entityType));
 
@@ -198,7 +198,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
 
             var transformedEntityName = EntityTypeTransformationService.TransformTypeEntityName(entityType.Name);
-            
+
             if (_options?.Value?.GenerateComments == true)
                 TemplateData.Add("comment", GenerateComment(entityType.GetComment(), 1));
             TemplateData.Add("class", transformedEntityName);
@@ -257,9 +257,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 {
                     GeneratePropertyDataAnnotations(property);
                 }
-                
+
                 var propertyType = CSharpHelper.Reference(property.ClrType);
-                if (UseNullableReferenceTypes 
+                if (UseNullableReferenceTypes
                     && property.IsNullable
                     && !propertyType.EndsWith("?")) {
                         propertyType += "?";
@@ -642,7 +642,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     inversePropertyAttribute.AddParameter(
                         !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
                                 m => m.Name == inverseNavigation.DeclaringEntityType.Name ||
-                                    EntityTypeTransformationService.TransformNavPropertyName(m.Name, navigation.TargetEntityType.Name) 
+                                    EntityTypeTransformationService.TransformNavPropertyName(m.Name, navigation.TargetEntityType.Name)
                                         == EntityTypeTransformationService.TransformNavPropertyName(inverseNavigation.DeclaringEntityType.Name, navigation.TargetEntityType.Name))
                             ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringType.Name)}.{propertyName})"
                             : CSharpHelper.Literal(propertyName));
@@ -704,7 +704,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         //            inversePropertyAttribute.AddParameter(
         //                !navigation.DeclaringEntityType.GetPropertiesAndNavigations().Any(
         //                        m => m.Name == inverseNavigation.DeclaringEntityType.Name ||
-        //                            EntityTypeTransformationService.TransformNavPropertyName(m.Name, navigation.TargetEntityType.Name) 
+        //                            EntityTypeTransformationService.TransformNavPropertyName(m.Name, navigation.TargetEntityType.Name)
         //                                == EntityTypeTransformationService.TransformNavPropertyName(inverseNavigation.DeclaringEntityType.Name, navigation.TargetEntityType.Name))
         //                    ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringType.Name)}.{propertyName})"
         //                    : CSharpHelper.Literal(propertyName));

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -340,18 +340,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         GenerateNavigationDataAnnotations(navigation);
                     }
 
-                    var propertyIsNullable = !navigation.IsCollection && (
-                        navigation.IsOnDependent
-                        ? !navigation.ForeignKey.IsRequired
-                        : !navigation.ForeignKey.IsRequiredDependent
-                    );
+                    var propertyIsNullable = !navigation.IsCollection &&
+                        UseNullableReferenceTypes &&
+                        !navigation.ForeignKey.IsRequired;
                     var navPropertyType = navigation.TargetEntityType.Name;
-                    if (UseNullableReferenceTypes &&
-                        !navPropertyType.EndsWith("?") &&
-                        propertyIsNullable) {
+                    if (propertyIsNullable &&
+                        !navPropertyType.EndsWith("?")) {
                         navPropertyType += "?";
                     }
-
                     navProperties.Add(new Dictionary<string, object>
                     {
                         { "nav-property-collection", navigation.IsCollection },
@@ -391,15 +387,12 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         GenerateNavigationDataAnnotations(navigation);
                     }
 
-                    var propertyIsNullable = !navigation.IsCollection && (
-                        navigation.IsOnDependent
-                        ? !navigation.ForeignKey.IsRequired
-                        : !navigation.ForeignKey.IsRequiredDependent
-                    );
+                    var propertyIsNullable = !navigation.IsCollection &&
+                        UseNullableReferenceTypes &&
+                        !navigation.ForeignKey.IsRequired;
                     var navPropertyType = navigation.TargetEntityType.Name;
-                    if (UseNullableReferenceTypes &&
-                        !navPropertyType.EndsWith("?") &&
-                        propertyIsNullable) {
+                    if (propertyIsNullable &&
+                        !navPropertyType.EndsWith("?")) {
                         navPropertyType += "?";
                     }
                     navProperties.Add(new Dictionary<string, object>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
@@ -4,6 +4,7 @@
 // Modifications copyright(C) 2019 Tony Sneed.
 
 using System.IO;
+using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars.Internal;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -117,6 +118,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             string generatedCode;
 
+            var useNullableReferenceTypes = options.UseNullableReferenceTypes
+                || _options?.Value?.EnableNullableReferenceTypes == true;
+
             if (!(CSharpDbContextGenerator is NullCSharpDbContextGenerator))
             {
                 generatedCode = CSharpDbContextGenerator.WriteCode(
@@ -126,6 +130,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     options.ContextNamespace,
                     options.ModelNamespace,
                     options.UseDataAnnotations,
+                    useNullableReferenceTypes,
                     options.SuppressConnectionStringWarning,
                     options.SuppressOnConfiguring);
 
@@ -143,12 +148,17 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             {
                 foreach (var entityType in model.GetScaffoldEntityTypes(_options.Value))
                 {
+                    if (IsManyToManyJoinEntityType(entityType))
+                    {
+                        continue;
+                    }
                     generatedCode = CSharpEntityTypeGenerator.WriteCode(
                         entityType,
                         options.ModelNamespace,
-                        options.UseDataAnnotations);
+                        options.UseDataAnnotations,
+                        useNullableReferenceTypes);
 
-                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.DisplayName());
+                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.Name);
                     var schema = !string.IsNullOrEmpty(entityType.GetTableName())
                         ? entityType.GetSchema()
                         : entityType.GetViewSchema();
@@ -165,6 +175,33 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             }
 
             return resultingFiles;
+        }
+
+
+        internal static bool IsManyToManyJoinEntityType(IEntityType entityType)
+        {
+            if (!entityType.GetNavigations().Any()
+                && !entityType.GetSkipNavigations().Any())
+            {
+                var primaryKey = entityType.FindPrimaryKey();
+                var properties = entityType.GetProperties().ToList();
+                var foreignKeys = entityType.GetForeignKeys().ToList();
+                if (primaryKey != null
+                    && primaryKey.Properties.Count > 1
+                    && foreignKeys.Count == 2
+                    && primaryKey.Properties.Count == properties.Count
+                    && foreignKeys[0].Properties.Count + foreignKeys[1].Properties.Count == properties.Count
+                    && !foreignKeys[0].Properties.Intersect(foreignKeys[1].Properties).Any()
+                    && foreignKeys[0].IsRequired
+                    && foreignKeys[1].IsRequired
+                    && !foreignKeys[0].IsUnique
+                    && !foreignKeys[1].IsUnique)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
@@ -74,8 +74,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="cSharpHelper">CSharp helper.</param>
         /// <param name="options">Handlebar scaffolding options.</param>
         public HbsCSharpModelGenerator(
-            [NotNull] ModelCodeGeneratorDependencies dependencies, 
-            [NotNull] ICSharpDbContextGenerator cSharpDbContextGenerator, 
+            [NotNull] ModelCodeGeneratorDependencies dependencies,
+            [NotNull] ICSharpDbContextGenerator cSharpDbContextGenerator,
             [NotNull] ICSharpEntityTypeGenerator cSharpEntityTypeGenerator,
             [NotNull] IHbsHelperService handlebarsHelperService,
             [NotNull] IHbsBlockHelperService handlebarsBlockHelperService,
@@ -118,9 +118,6 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             string generatedCode;
 
-            var useNullableReferenceTypes = options.UseNullableReferenceTypes
-                || _options?.Value?.EnableNullableReferenceTypes == true;
-
             if (!(CSharpDbContextGenerator is NullCSharpDbContextGenerator))
             {
                 generatedCode = CSharpDbContextGenerator.WriteCode(
@@ -130,7 +127,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     options.ContextNamespace,
                     options.ModelNamespace,
                     options.UseDataAnnotations,
-                    useNullableReferenceTypes,
+                    options.UseNullableReferenceTypes,
                     options.SuppressConnectionStringWarning,
                     options.SuppressOnConfiguring);
 
@@ -156,7 +153,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         entityType,
                         options.ModelNamespace,
                         options.UseDataAnnotations,
-                        useNullableReferenceTypes);
+                        options.UseNullableReferenceTypes);
 
                     var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.Name);
                     var schema = !string.IsNullOrEmpty(entityType.GetTableName())
@@ -168,8 +165,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     resultingFiles.AdditionalFiles.Add(
                         new ScaffoldedFile
                         {
-                            Path = entityTypeFileName, 
-                            Code = generatedCode 
+                            Path = entityTypeFileName,
+                            Code = generatedCode
                         });
                 }
             }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsReverseEngineerScaffolder.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsReverseEngineerScaffolder.cs
@@ -35,13 +35,13 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="connectionStringResolver">Connection string resolver.</param>
         /// <param name="reporter">Operation reporter.</param>
         public HbsReverseEngineerScaffolder(
-            [NotNull] IDatabaseModelFactory databaseModelFactory,
-            [NotNull] IScaffoldingModelFactory scaffoldingModelFactory,
-            [NotNull] IModelCodeGeneratorSelector modelCodeGeneratorSelector,
-            [NotNull] ICSharpUtilities cSharpUtilities,
-            [NotNull] ICSharpHelper cSharpHelper,
-            [NotNull] INamedConnectionStringResolver connectionStringResolver,
-            [NotNull] IOperationReporter reporter)
+            IDatabaseModelFactory databaseModelFactory,
+            IScaffoldingModelFactory scaffoldingModelFactory,
+            IModelCodeGeneratorSelector modelCodeGeneratorSelector,
+            ICSharpUtilities cSharpUtilities,
+            ICSharpHelper cSharpHelper,
+            IDesignTimeConnectionStringResolver connectionStringResolver,
+            IOperationReporter reporter)
             : base(databaseModelFactory, scaffoldingModelFactory, modelCodeGeneratorSelector, cSharpUtilities, cSharpHelper, connectionStringResolver, reporter)
         {
             Check.NotNull(databaseModelFactory, nameof(databaseModelFactory));

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
@@ -80,7 +80,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="namespace">Entity type namespace.</param>
         /// <param name="useDataAnnotations">If true use data annotations.</param>
         /// <returns>Generated entity type.</returns>
-        public override string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations)
+        public override string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations, bool useNullableReferenceTypes)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(@namespace, nameof(@namespace));
@@ -174,7 +174,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             var properties = new List<Dictionary<string, object>>();
 
-            foreach (var property in entityType.GetProperties().OrderBy(p => p.GetColumnOrdinal()))
+            foreach (var property in entityType.GetProperties().OrderBy(p => p.GetColumnOrder()))
             {
                 properties.Add(new Dictionary<string, object>
                 {

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
@@ -49,6 +49,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         protected virtual IEntityTypeTransformationService EntityTypeTransformationService { get; }
 
         /// <summary>
+        /// Indicates if nullable reference types should be used.
+        /// </summary>
+        protected bool UseNullableReferenceTypes { get; private set; }
+
+        /// <summary>
         /// Constructor for the Handlebars entity types generator.
         /// </summary>
         /// <param name="annotationCodeGenerator">Annotation code generator.</param>
@@ -79,12 +84,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="entityType">Represents an entity type in an <see cref="T:Microsoft.EntityFrameworkCore.Metadata.IModel" />.</param>
         /// <param name="namespace">Entity type namespace.</param>
         /// <param name="useDataAnnotations">If true use data annotations.</param>
+        /// <param name="useNullableReferenceTypes">If true use nullable reference types.</param>
         /// <returns>Generated entity type.</returns>
         public override string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations, bool useNullableReferenceTypes)
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(@namespace, nameof(@namespace));
 
+            UseNullableReferenceTypes = useNullableReferenceTypes;
             TemplateData = new Dictionary<string, object>();
             GenerateImports(entityType);
             GenerateClass(entityType);
@@ -183,7 +190,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     { "property-annotations",  new List<Dictionary<string, object>>() },
                     { "property-comment", property.GetComment() },
                     { "property-isnullable", property.IsNullable },
-                    { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
+                    { "nullable-reference-types", UseNullableReferenceTypes }
                 });
             }
 
@@ -216,7 +223,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         { "nav-property-type", navigation.TargetEntityType.Name },
                         { "nav-property-name", TypeScriptHelper.ToCamelCase(navigation.Name) },
                         { "nav-property-annotations", new List<Dictionary<string, object>>() },
-                        { "nullable-reference-types",  _options?.Value?.EnableNullableReferenceTypes == true }
+                        { "nullable-reference-types",  UseNullableReferenceTypes }
                     });
                 }
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptModelGenerator.cs
@@ -118,6 +118,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     options.ContextNamespace,
                     options.ModelNamespace,
                     options.UseDataAnnotations,
+                    options.UseNullableReferenceTypes,
                     options.SuppressConnectionStringWarning,
                     options.SuppressOnConfiguring);
 
@@ -138,9 +139,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     generatedCode = CSharpEntityTypeGenerator.WriteCode(
                         entityType,
                         options.ModelNamespace,
-                        options.UseDataAnnotations);
+                        options.UseDataAnnotations,
+                        options.UseNullableReferenceTypes);
 
-                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.DisplayName());
+                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.Name);
                     var entityTypeFileName = transformedFileName + FileExtension;
                     if (_options?.Value?.EnableSchemaFolders == true) {
                         entityTypeFileName = entityType.GetSchema() + @"\" + entityTypeFileName;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeExtensions.cs
@@ -26,12 +26,34 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 var excludedTables = options.ExcludedTables.Select(t => new TableAndSchema(t)).ToList();
                 navigations = navigations.Where(n =>
                         !excludedTables.Any(e =>
-                            (string.IsNullOrEmpty(e.Schema) || 
+                            (string.IsNullOrEmpty(e.Schema) ||
                              string.Equals(n.ForeignKey.GetRelatedEntityType(n.DeclaringEntityType).GetSchema(), e.Schema, StringComparison.OrdinalIgnoreCase))
                             && string.Equals(n.ForeignKey.GetRelatedEntityType(n.DeclaringEntityType).GetTableName(), e.Table, StringComparison.OrdinalIgnoreCase)))
                         .ToList();
             }
 
+            return navigations;
+        }
+
+        /// <summary>
+        /// Gets all entity type skip navigations that are to be used in scaffolding.
+        /// </summary>
+        /// <param name="entityType">Represents an entity type in an IModel.</param>
+        /// <param name="options">Scaffolding options to use in determining entity types.</param>
+        /// <returns>Filtered set of navigations for scaffolding.</returns>
+        public static IEnumerable<ISkipNavigation> GetScaffoldSkipNavigations(this IEntityType entityType, HandlebarsScaffoldingOptions options)
+        {
+            var navigations = entityType.GetSkipNavigations();
+            if (options.ExcludedTables != null && options.ExcludedTables.Any())
+            {
+                var excludedTables = options.ExcludedTables.Select(t => new TableAndSchema(t)).ToList();
+                navigations = navigations.Where(n =>
+                    !excludedTables.Any(e =>
+                        (string.IsNullOrEmpty(e.Schema) ||
+                         string.Equals(n.ForeignKey.GetRelatedEntityType(n.DeclaringEntityType).GetSchema(), e.Schema, StringComparison.OrdinalIgnoreCase))
+                         && string.Equals(n.ForeignKey.GetRelatedEntityType(n.DeclaringEntityType).GetTableName(), e.Table, StringComparison.OrdinalIgnoreCase)))
+                    .ToList();
+            }
             return navigations;
         }
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IModelExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IModelExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 namespace EntityFrameworkCore.Scaffolding.Handlebars
 {
     /// <summary>
-    /// Extension methods for Entity Framework <see cref="IModel"/> class.
+    /// Extension methods for Entity Framework <see cref="IMutableModel"/> class.
     /// </summary>
     public static class IModelExtensions
     {

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IModelExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IModelExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 namespace EntityFrameworkCore.Scaffolding.Handlebars
 {
     /// <summary>
-    /// Extension methods for Entity Framework <see cref="IMutableModel"/> class.
+    /// Extension methods for Entity Framework <see cref="IModel"/> class.
     /// </summary>
     public static class IModelExtensions
     {

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/NullCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/NullCSharpDbContextGenerator.cs
@@ -17,10 +17,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="contextNamespace">Context namespace.</param>
         /// <param name="modelNamespace">Model namespace.</param>
         /// <param name="useDataAnnotations">If false use fluent modeling API.</param>
+        /// <param name="useNullableReferenceTypes">If true use nullable reference types.</param>
         /// <param name="suppressConnectionStringWarning">Suppress connection string warning.</param>
         /// <param name="suppressOnConfiguring">Suppress OnConfiguring method.</param>
         /// <returns>DbContext class.</returns>
-        public string WriteCode(IModel model, string contextName, string connectionString, string contextNamespace, string modelNamespace, bool useDataAnnotations, bool suppressConnectionStringWarning, bool suppressOnConfiguring)
+        public string WriteCode(IModel model, string contextName, string connectionString, string contextNamespace, string modelNamespace, bool useDataAnnotations, bool useNullableReferenceTypes, bool suppressConnectionStringWarning, bool suppressOnConfiguring)
         {
             return string.Empty;
         }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/NullCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/NullCSharpEntityTypeGenerator.cs
@@ -14,8 +14,9 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="entityType">Represents an entity type in an <see cref="T:Microsoft.EntityFrameworkCore.Metadata.IModel" />.</param>
         /// <param name="namespace">Entity type namespace.</param>
         /// <param name="useDataAnnotations">If true use data annotations.</param>
+        /// <param name="useNullableReferenceTypes">If true use nullable reference types.</param>
         /// <returns>Generated entity type.</returns>
-        public string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations)
+        public string WriteCode(IEntityType entityType, string @namespace, bool useDataAnnotations, bool useNullableReferenceTypes)
         {
             return string.Empty;
         }

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -32,13 +32,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation(""Relational:Collation"", ""SQL_Latin1_General_CP1_CI_AS"");
-
             modelBuilder.Entity<Category>(entity =>
             {
                 entity.ToTable(""Category"");
 
                 entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryId).HasDefaultValue(0);
 
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
@@ -51,6 +51,10 @@ namespace FakeNamespace
                 entity.ToTable(""Product"");
 
                 entity.HasIndex(e => e.CategoryId);
+
+                entity.Property(e => e.ProductId).HasDefaultValue(0);
+
+                entity.Property(e => e.Discontinued).HasDefaultValue(false);
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -96,13 +100,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation(""Relational:Collation"", ""SQL_Latin1_General_CP1_CI_AS"");
-
             modelBuilder.Entity<Category>(entity =>
             {
                 entity.ToTable(""Category"");
 
                 entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryId).HasDefaultValue(0);
 
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
@@ -115,6 +119,10 @@ namespace FakeNamespace
                 entity.ToTable(""Product"");
 
                 entity.HasIndex(e => e.CategoryId);
+
+                entity.Property(e => e.ProductId).HasDefaultValue(0);
+
+                entity.Property(e => e.Discontinued).HasDefaultValue(false);
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -169,17 +177,21 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation(""Relational:Collation"", ""SQL_Latin1_General_CP1_CI_AS"");
-
             modelBuilder.Entity<Category>(entity =>
             {
                 entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryId).HasDefaultValue(0);
 
                 entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>
             {
+                entity.Property(e => e.ProductId).HasDefaultValue(0);
+
+                entity.Property(e => e.Discontinued).HasDefaultValue(false);
+
                 entity.Property(e => e.RowVersion)
                     .IsRowVersion()
                     .IsConcurrencyToken();

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -38,8 +38,6 @@ namespace FakeNamespace
 
                 entity.HasComment(""A category of products"");
 
-                entity.Property(e => e.CategoryId).HasDefaultValue(0);
-
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
                     .HasMaxLength(15)
@@ -51,10 +49,6 @@ namespace FakeNamespace
                 entity.ToTable(""Product"");
 
                 entity.HasIndex(e => e.CategoryId);
-
-                entity.Property(e => e.ProductId).HasDefaultValue(0);
-
-                entity.Property(e => e.Discontinued).HasDefaultValue(false);
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -106,8 +100,6 @@ namespace FakeNamespace
 
                 entity.HasComment(""A category of products"");
 
-                entity.Property(e => e.CategoryId).HasDefaultValue(0);
-
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
                     .HasMaxLength(15)
@@ -119,10 +111,6 @@ namespace FakeNamespace
                 entity.ToTable(""Product"");
 
                 entity.HasIndex(e => e.CategoryId);
-
-                entity.Property(e => e.ProductId).HasDefaultValue(0);
-
-                entity.Property(e => e.Discontinued).HasDefaultValue(false);
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -181,17 +169,11 @@ namespace FakeNamespace
             {
                 entity.HasComment(""A category of products"");
 
-                entity.Property(e => e.CategoryId).HasDefaultValue(0);
-
                 entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
             });
 
             modelBuilder.Entity<Product>(entity =>
             {
-                entity.Property(e => e.ProductId).HasDefaultValue(0);
-
-                entity.Property(e => e.Discontinued).HasDefaultValue(false);
-
                 entity.Property(e => e.RowVersion)
                     .IsRowVersion()
                     .IsConcurrencyToken();

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -48,7 +48,7 @@ namespace FakeNamespace
             {
                 entity.ToTable(""Product"");
 
-                entity.HasIndex(e => e.CategoryId);
+                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -110,7 +110,7 @@ namespace FakeNamespace
             {
                 entity.ToTable(""Product"");
 
-                entity.HasIndex(e => e.CategoryId);
+                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -141,14 +141,14 @@ namespace FakeNamespace
             Products = new HashSet<Product>();
         }
 
-        public int CategoryId { get; set; } = default!;
+        public int CategoryId { get; set; }
 
         /// <summary>
         /// The name of a category
         /// </summary>
-        public string CategoryName { get; set; } = default!;
+        public string CategoryName { get; set; } = null!;
 
-        public virtual ICollection<Product> Products { get; set; } = default!;
+        public virtual ICollection<Product> Products { get; set; }
     }
 }
 ";
@@ -161,10 +161,10 @@ namespace FakeNamespace
 {
     public partial class Product
     {
-        public int ProductId { get; set; } = default!;
-        public string ProductName { get; set; } = default!;
+        public int ProductId { get; set; }
+        public string ProductName { get; set; } = null!;
         public decimal? UnitPrice { get; set; }
-        public bool Discontinued { get; set; } = default!;
+        public bool Discontinued { get; set; }
         public byte[]? RowVersion { get; set; }
         public int? CategoryId { get; set; }
 

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
@@ -32,13 +32,13 @@ namespace FakeNamespace
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation(""Relational:Collation"", ""SQL_Latin1_General_CP1_CI_AS"");
-
             modelBuilder.Entity<Category>(entity =>
             {
                 entity.ToTable(""Category"");
 
                 entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryId).HasDefaultValue(0);
 
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
@@ -51,6 +51,10 @@ namespace FakeNamespace
                 entity.ToTable(""Product"");
 
                 entity.HasIndex(e => e.CategoryId);
+
+                entity.Property(e => e.ProductId).HasDefaultValue(0);
+
+                entity.Property(e => e.Discontinued).HasDefaultValue(false);
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
@@ -48,7 +48,7 @@ namespace FakeNamespace
             {
                 entity.ToTable(""Product"");
 
-                entity.HasIndex(e => e.CategoryId);
+                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
@@ -38,8 +38,6 @@ namespace FakeNamespace
 
                 entity.HasComment(""A category of products"");
 
-                entity.Property(e => e.CategoryId).HasDefaultValue(0);
-
                 entity.Property(e => e.CategoryName)
                     .IsRequired()
                     .HasMaxLength(15)
@@ -51,10 +49,6 @@ namespace FakeNamespace
                 entity.ToTable(""Product"");
 
                 entity.HasIndex(e => e.CategoryId);
-
-                entity.Property(e => e.ProductId).HasDefaultValue(0);
-
-                entity.Property(e => e.Discontinued).HasDefaultValue(false);
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()

--- a/test/Scaffolding.Handlebars.Tests/Fakes/FakeScaffoldingModelFactory.cs
+++ b/test/Scaffolding.Handlebars.Tests/Fakes/FakeScaffoldingModelFactory.cs
@@ -6,6 +6,7 @@
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
@@ -21,8 +22,9 @@ namespace Scaffolding.Handlebars.Tests.Fakes
             IPluralizer pluralizer,
             ICSharpUtilities cSharpUtilities,
             IScaffoldingTypeMapper scaffoldingTypeMapper,
-            LoggingDefinitions loggingDefinitions)
-            : base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper, loggingDefinitions)
+            LoggingDefinitions loggingDefinitions,
+            IModelRuntimeInitializer modelRuntimeInitializer)
+            : base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper, loggingDefinitions, modelRuntimeInitializer)
         {
         }
 

--- a/test/Scaffolding.Handlebars.Tests/Fakes/TestRelationalTypeMappingSource.cs
+++ b/test/Scaffolding.Handlebars.Tests/Fakes/TestRelationalTypeMappingSource.cs
@@ -16,7 +16,7 @@ namespace Scaffolding.Handlebars.Tests.Fakes
     public class TestRelationalTypeMappingSource : RelationalTypeMappingSource
     {
         private static readonly RelationalTypeMapping _string
-            = new StringTypeMapping("just_string(2000)");
+            = new StringTypeMapping("just_string(2000)", dbType: DbType.String);
 
         private static readonly RelationalTypeMapping _binary
             = new ByteArrayTypeMapping("just_binary(max)", dbType: DbType.Binary);

--- a/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
@@ -207,10 +207,7 @@ namespace Scaffolding.Handlebars.Tests
             // Arrange
             Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
             var revEngOptions = ReverseEngineerOptions.EntitiesOnly;
-            var scaffolder = CreateScaffolder(revEngOptions, options =>
-            {
-                options.EnableNullableReferenceTypes = true;
-            });
+            var scaffolder = CreateScaffolder(revEngOptions);
 
             // Act
             var model = scaffolder.ScaffoldModel(
@@ -224,6 +221,7 @@ namespace Scaffolding.Handlebars.Tests
                     ContextName = Constants.Parameters.ContextName,
                     ContextDir = Constants.Parameters.ProjectPath,
                     UseDataAnnotations = false,
+                    UseNullableReferenceTypes = true,
                     Language = "C#",
                 });
 

--- a/test/Scaffolding.Handlebars.Tests/IModelExtensionsTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/IModelExtensionsTests.cs
@@ -30,7 +30,7 @@ namespace Scaffolding.Handlebars.Tests
                 ExcludedTables = new List<string> {"Product"}
             };
 
-            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
             Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Product");
         }
@@ -50,7 +50,7 @@ namespace Scaffolding.Handlebars.Tests
                 ExcludedTables = new List<string> { "dbo.Category", "dbo.Product" }
             };
 
-            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
             Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Category");
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
         }
@@ -70,7 +70,7 @@ namespace Scaffolding.Handlebars.Tests
                 ExcludedTables = null
             };
 
-            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
         }
@@ -90,7 +90,7 @@ namespace Scaffolding.Handlebars.Tests
                 ExcludedTables = new List<string> { "Product" }
             };
 
-            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
             Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Product");
         }
@@ -110,7 +110,7 @@ namespace Scaffolding.Handlebars.Tests
                 ExcludedTables = new List<string> { "dbo.Category", "dbo.Product" }
             };
 
-            var entityTypes = builder.Model.GetScaffoldEntityTypes(options);
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
             Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Category");
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
         }

--- a/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
+++ b/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
@@ -11,10 +11,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>

--- a/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
+++ b/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
@@ -11,9 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />


### PR DESCRIPTION
**Describe your proposed changes**
This set of changes updates the project to EF Core 6 (Issue #181), including the Many-to-Many relationship (skip navigation) scaffolding.

I removed the `EnableNullableReferenceTypes` Handlebars option in favor of using the built-in option for `UseNullableReferenceTypes`, which now needed to be passed to the internal `Write*` methods. A side benefit of this is that enabling nullable references only needs to happen in one place now (in the csproj file). Other than that, I did my best to keep everything consistent while also updating various aspects so the resultant output more closely matched the default scaffolding output of EF Core 6.

It felt like there was a lot of things to update to make it compatible with EF Core 6 and support the many-to-many relationships, but all of the test cases are passing, the samples projects are transforming as I expected and my personal projects also update as expected.
