### PR TITLE
Remove skip-nav-properties from Properties.hbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Before creating a pull request, please refer to the [Contributing Guidelines](ht
 
 ## Prerequisites
 
-- [Visual Studio 2022](https://www.visualstudio.com/downloads/) or greater.
-- [.NET Core 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) RC2 or greater.
+- [Visual Studio 2022](https://www.visualstudio.com/downloads/) or greater, [JetBrains Rider](https://www.jetbrains.com/rider) 2021.3 or greater.
+- [.NET Core 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) or greater.
 - [EF Core CLI 6.0](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) or greater.
   - Install global `dotnet-ef` tool.
     ```
     dotnet tool install --global dotnet-ef
     ```
-  - Update global `dotnet-ef` tool.
+  - Or update global `dotnet-ef` tool.
     ```
     dotnet tool update --global dotnet-ef
     ```
@@ -34,6 +34,21 @@ Before creating a pull request, please refer to the [Contributing Guidelines](ht
     - Create a new database named **NorthwindSlim**.
     - Download the `NorthwindSlim.sql` file from <https://github.com/TrackableEntities/northwind-slim>.
     - Unzip **NorthwindSlim.sql** and run the script to create tables and populate them with data.
+
+## Upgrading from v5 to v6
+
+1. Upgrade `TargetFramework` in **.csproj** file to `net6.0`.
+   - Optional: Set `ImplicitUsings` to `enable`.
+   - Optional: Set `Nullable` ro `enable`.
+2. Update the following NuGet packages to `6.0.0` or later:
+   - Microsoft.EntityFrameworkCore.Design
+   - Microsoft.EntityFrameworkCore.SqlServer
+   - EntityFrameworkCore.Scaffolding.Handlebars
+3. Remove the `EnableNullableReferenceTypes` option from `services.AddHandlebarsScaffolding` in `ScaffoldingDesignTimeServices.ConfigureDesignTimeServices`.
+   - Version 6 relies on [support for nullable reference types in EF Core 6](https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types).
+4. Run `dotnet ef dbcontext scaffold` command to regenerate entities.
+   - You may retain your customized Handlebars templates.
+   - [Many-to-many relationships](https://docs.microsoft.com/en-us/ef/core/modeling/relationships?tabs=fluent-api%2Cfluent-api-simple-key%2Csimple-key#many-to-many) will be materialized without the need for an intermediate entity.
 
 ## Usage
 
@@ -94,8 +109,7 @@ Take advantage of C# nullable reference types by enabling them in your .csproj f
 
 ```xml
 <PropertyGroup>
-  <TargetFramework>netcoreapp3.1</TargetFramework>
-  <LangVersion>8.0</LangVersion>
+  <TargetFramework>net6.0</TargetFramework>
   <Nullable>enable</Nullable>
 </PropertyGroup>
 ```

--- a/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbConstructor.hbs
+++ b/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbConstructor.hbs
@@ -1,0 +1,3 @@
+﻿        public {{class}}(DbContextOptions<{{class}}> options) : base(options)
+        {
+        }

--- a/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbImports.hbs
+++ b/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbImports.hbs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+{{#if model-namespace}}
+using {{model-namespace}};
+{{/if}}
+{{#each model-imports}}
+using {{model-import}};
+{{/each}}

--- a/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbOnConfiguring.hbs
+++ b/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbOnConfiguring.hbs
@@ -1,0 +1,10 @@
+﻿        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+{{#if connectionstring-warning}}
+{{connectionstring-warning}}
+{{/if}}
+                optionsBuilder{{options-builder-provider}};
+            }
+        }

--- a/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbSets.hbs
+++ b/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptDbContext/Partials/DbSets.hbs
@@ -1,0 +1,3 @@
+﻿{{#each dbsets}}
+        public virtual DbSet<{{set-property-type}}> {{set-property-name}} { get; set; }{{#if nullable-reference-types }} = default!;{{/if}}
+{{/each}}

--- a/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/sample/ScaffoldingSample.TypeScript/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -15,12 +15,3 @@
 {{/if}}
 {{/each}}
 {{/if}}
-{{#if skip-nav-properties}}
-{{#each skip-nav-properties}}
-{{#if nav-property-collection}}
-    {{nav-property-name}}: {{nav-property-type}}[];
-{{else}}
-    {{nav-property-name}}: {{nav-property-type}};
-{{/if}}
-{{/each}}
-{{/if}}

--- a/sample/ScaffoldingSample.TypeScript/Models/Category.ts
+++ b/sample/ScaffoldingSample.TypeScript/Models/Category.ts
@@ -1,13 +1,7 @@
 ﻿import { Product } from './Product';
 
-/**
-* hello table Customer
-*/
 export interface Category {
     categoryId: number;
-    /**
-    * hello CompanyName
-    */
     categoryName: string;
     products: Product[];
 }

--- a/sample/ScaffoldingSample.TypeScript/Models/Employee.ts
+++ b/sample/ScaffoldingSample.TypeScript/Models/Employee.ts
@@ -1,4 +1,4 @@
-﻿import { EmployeeTerritory } from './EmployeeTerritory';
+﻿import { Territory } from './Territory';
 
 export interface Employee {
     employeeId: number;
@@ -8,5 +8,5 @@ export interface Employee {
     hireDate: Date;
     city: string;
     country: string;
-    employeeTerritories: EmployeeTerritory[];
+    territories: Territory[];
 }

--- a/sample/ScaffoldingSample.TypeScript/Models/EmployeeTerritory.ts
+++ b/sample/ScaffoldingSample.TypeScript/Models/EmployeeTerritory.ts
@@ -1,9 +1,5 @@
-﻿import { Employee } from './Employee';
-import { Territory } from './Territory';
-
+﻿
 export interface EmployeeTerritory {
     employeeId: number;
     territoryId: string;
-    employee: Employee;
-    territory: Territory;
 }

--- a/sample/ScaffoldingSample.TypeScript/Models/Territory.ts
+++ b/sample/ScaffoldingSample.TypeScript/Models/Territory.ts
@@ -1,7 +1,7 @@
-﻿import { EmployeeTerritory } from './EmployeeTerritory';
+﻿import { Employee } from './Employee';
 
 export interface Territory {
     territoryId: string;
     territoryDescription: string;
-    employeeTerritories: EmployeeTerritory[];
+    employees: Employee[];
 }

--- a/sample/ScaffoldingSample.TypeScript/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample.TypeScript/ScaffoldingDesignTimeServices.cs
@@ -14,6 +14,9 @@ namespace ScaffoldingSample
     {
         public void ConfigureDesignTimeServices(IServiceCollection services)
         {
+            // Uncomment to launch JIT debugger and hit breakpoints
+            //System.Diagnostics.Debugger.Launch();
+
             // Add Handlebars scaffolding templates
             services.AddHandlebarsScaffolding(ReverseEngineerOptions.EntitiesOnly, LanguageOptions.TypeScript);
         }

--- a/sample/ScaffoldingSample/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/sample/ScaffoldingSample/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -23,19 +23,6 @@
 {{/if}}
 {{/each}}
 {{/if}}
-{{#if skip-nav-properties}}
-
-{{#each skip-nav-properties}}
-{{#each nav-property-annotations}}
-        {{{nav-property-annotation}}}
-{{/each}}
-{{#if nav-property-collection}}
-        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
-{{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
-{{/if}}
-{{/each}}
-{{/if}}
 
         // My Handlebars Block Helper: {{#ifCond '1' '==' '1'}}True{{else}}False{{/ifCond}}
         // My Handlebars Block Helper: {{#ifCond '2' '==' '1'}}True{{else}}False{{/ifCond}}

--- a/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
@@ -19,7 +19,7 @@ namespace ScaffoldingSample
         public void ConfigureDesignTimeServices(IServiceCollection services)
         {
             // Uncomment to launch JIT debugger and hit breakpoints
-            System.Diagnostics.Debugger.Launch();
+            //System.Diagnostics.Debugger.Launch();
 
             // Add Handlebars scaffolding templates
             services.AddHandlebarsScaffolding(options =>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -23,16 +23,3 @@
 {{/if}}
 {{/each}}
 {{/if}}
-{{#if skip-nav-properties}}
-
-{{#each skip-nav-properties}}
-{{#each nav-property-annotations}}
-        {{{nav-property-annotation}}}
-{{/each}}
-{{#if nav-property-collection}}
-        public virtual ICollection<{{nav-property-type}}> {{nav-property-name}} { get; set; }
-{{else}}
-        public virtual {{nav-property-type}} {{nav-property-name}} { get; set; }{{#if nullable-reference-types}}{{#unless nav-property-isnullable}} = null!;{{/unless}}{{/if}}
-{{/if}}
-{{/each}}
-{{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/TypeScriptEntityType/Partials/Properties.hbs
@@ -15,12 +15,3 @@
 {{/if}}
 {{/each}}
 {{/if}}
-{{#if skip-nav-properties}}
-{{#each skip-nav-properties}}
-{{#if nav-property-collection}}
-    {{nav-property-name}}: {{nav-property-type}}[];
-{{else}}
-    {{nav-property-name}}: {{nav-property-type}};
-{{/if}}
-{{/each}}
-{{/if}}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.0.0-preview1</Version>
+    <Version>6.0.0-preview2</Version>
     <Authors>Tony Sneed</Authors>
     <Company>Tony Sneed</Company>
     <Title>Entity Framework Core Scaffolding with Handlebars</Title>
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>scaffolding reverse-engineer entity-framework-core handlebars</PackageTags>
-    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v6.0.0-preview1</PackageReleaseNotes>
+    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v6.0.0-preview2</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <IncludeSource>true</IncludeSource>
     <SignAssembly>true</SignAssembly>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HandlebarsScaffoldingOptions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HandlebarsScaffoldingOptions.cs
@@ -51,6 +51,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         public bool EnableSchemaFolders { get; set; }
 
         /// <summary>
+        /// Gets or sets whether entity properties are declared and instantiated in the C# 8.0+ nullable reference types style (optional).
+        /// https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
+        /// https://docs.microsoft.com/en-us/ef/core/miscellaneous/nullable-reference-types
+        /// </summary>
+        [Obsolete("Deprecated in favor of support for nullable reference types in EF Core 6.", true)]
+        public bool EnableNullableReferenceTypes { get; set; }
+
+        /// <summary>
         /// Gets or sets whether table and column descriptions generate XML comments.
         /// </summary>
         public bool GenerateComments { get; set; } = true;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -9,7 +9,6 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using EntityFrameworkCore.Scaffolding.Handlebars.Internal;
-using System.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -407,7 +406,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 }
 
                 var transformedNavProperties = EntityTypeTransformationService.TransformNavigationProperties(navProperties);
-                TemplateData.Add("skip-nav-properties", transformedNavProperties);
+                if (TemplateData.TryGetValue("nav-properties", out var navProps)
+                    && navProps is List<Dictionary<string, object>> existingNavProps)
+                    transformedNavProperties.ForEach(item => existingNavProps.Add(item));
+                else
+                    TemplateData.Add("nav-properties", transformedNavProperties);
             }
         }
 


### PR DESCRIPTION
Fix GenerateImports in TypeScript entity generator.
Update version to 6.0.0-preview2.

Makes it possible to upgrade from v5 to v6 without re-creating templates.