### PR TITLE
Add .ToTable and .HasColumnName methods when using Transforms

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -533,9 +533,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         private void GenerateColumnAttribute(IProperty property)
         {
             var columnName = property.GetColumnBaseName();
+            var propertyName = EntityTypeTransformationService.TransformPropertyName(property.DeclaringEntityType, property.Name, property.DeclaringType.Name);
             var columnType = property.GetConfiguredColumnType();
 
-            var delimitedColumnName = columnName != null && columnName != property.Name ? CSharpHelper.Literal(columnName) : null;
+            var delimitedColumnName = columnName != null && columnName != propertyName ? CSharpHelper.Literal(columnName) : null;
             var delimitedColumnType = columnType != null ? CSharpHelper.Literal(columnType) : null;
 
             if ((delimitedColumnName ?? delimitedColumnType) != null)

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -74,7 +74,80 @@ namespace FakeNamespace
 }
 ";
         }
+        private static class ExpectedContextsWithTransformMappings
+        {
+            public static string ContextClass =
+@"using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
+namespace FakeNamespace
+{
+    public partial class FakeDbContext : DbContext
+    {
+        public virtual DbSet<CategoryRenamed> Category { get; set; }
+        public virtual DbSet<ProductRenamed> Product { get; set; }
+
+        public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
+        {
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see http://go.microsoft.com/fwlink/?LinkId=723263.
+                optionsBuilder.UseSqlServer(""" + Constants.Connections.SqlServerConnection.Replace(@"\",@"\\") + @""");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CategoryRenamed>(entity =>
+            {
+                entity.ToTable(""Category"");
+
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryNameRenamed)
+                    .HasColumnName(""CategoryName"")
+                    .IsRequired()
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<ProductRenamed>(entity =>
+            {
+                entity.ToTable(""Product"");
+
+                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
+
+                entity.Property(e => e.ProductName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.RowVersion)
+                    .IsRowVersion()
+                    .IsConcurrencyToken();
+
+                entity.Property(e => e.UnitPriceRenamed)
+                    .HasColumnName(""UnitPrice"")
+                    .HasColumnType(""money"");
+
+                entity.HasOne(d => d.Category)
+                    .WithMany(p => p.Product)
+                    .HasForeignKey(d => d.CategoryId);
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+";
+        }
         private static class ExpectedContextsSupressOnConfiguring
         {
             public static string ContextClass =
@@ -137,7 +210,71 @@ namespace FakeNamespace
 }
 ";
         }
+        private static class ExpectedContextsSupressOnConfiguringWithTransformMappings
+        {
+            public static string ContextClass =
+@"using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
+namespace FakeNamespace
+{
+    public partial class FakeDbContext : DbContext
+    {
+        public virtual DbSet<CategoryRenamed> Category { get; set; }
+        public virtual DbSet<ProductRenamed> Product { get; set; }
+
+        public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CategoryRenamed>(entity =>
+            {
+                entity.ToTable(""Category"");
+
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryNameRenamed)
+                    .HasColumnName(""CategoryName"")
+                    .IsRequired()
+                    .HasMaxLength(15)
+                    .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<ProductRenamed>(entity =>
+            {
+                entity.ToTable(""Product"");
+
+                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
+
+                entity.Property(e => e.ProductName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.RowVersion)
+                    .IsRowVersion()
+                    .IsConcurrencyToken();
+
+                entity.Property(e => e.UnitPriceRenamed)
+                    .HasColumnName(""UnitPrice"")
+                    .HasColumnType(""money"");
+
+                entity.HasOne(d => d.Category)
+                    .WithMany(p => p.Product)
+                    .HasForeignKey(d => d.CategoryId);
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+";
+        }
         public static class ExpectedContextsWithAnnotations
         {
             public static string ContextClass =
@@ -190,5 +327,58 @@ namespace FakeNamespace
 }
 ";
         }
+        public static class ExpectedContextsWithAnnotationsAndTransformMappings
+        {
+            public static string ContextClass =
+@"using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace FakeNamespace
+{
+    public partial class FakeDbContext : DbContext
+    {
+        public virtual DbSet<CategoryRenamed> Category { get; set; }
+        public virtual DbSet<ProductRenamed> Product { get; set; }
+
+        public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
+        {
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see http://go.microsoft.com/fwlink/?LinkId=723263.
+                optionsBuilder.UseSqlServer(""" + Constants.Connections.SqlServerConnection.Replace(@"\",@"\\") + @""");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<CategoryRenamed>(entity =>
+            {
+                entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryNameRenamed).HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<ProductRenamed>(entity =>
+            {
+                entity.Property(e => e.RowVersion)
+                    .IsRowVersion()
+                    .IsConcurrencyToken();
+            });
+
+            OnModelCreatingPartial(modelBuilder);
+        }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+    }
+}
+";
+        }
+
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -106,9 +106,13 @@ namespace FakeNamespace
         {
             modelBuilder.Entity<CategoryRenamed>(entity =>
             {
+                entity.HasKey(e => e.CategoryIdRenamed);
+
                 entity.ToTable(""Category"");
 
                 entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryIdRenamed).HasColumnName(""CategoryId"");
 
                 entity.Property(e => e.CategoryNameRenamed)
                     .HasColumnName(""CategoryName"")
@@ -119,9 +123,15 @@ namespace FakeNamespace
 
             modelBuilder.Entity<ProductRenamed>(entity =>
             {
+                entity.HasKey(e => e.ProductIdRenamed);
+
                 entity.ToTable(""Product"");
 
-                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
+                entity.HasIndex(e => e.CategoryIdRenamed, ""IX_Product_CategoryId"");
+
+                entity.Property(e => e.ProductIdRenamed).HasColumnName(""ProductId"");
+
+                entity.Property(e => e.CategoryIdRenamed).HasColumnName(""CategoryId"");
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -137,7 +147,7 @@ namespace FakeNamespace
 
                 entity.HasOne(d => d.Category)
                     .WithMany(p => p.Product)
-                    .HasForeignKey(d => d.CategoryId);
+                    .HasForeignKey(d => d.CategoryIdRenamed);
             });
 
             OnModelCreatingPartial(modelBuilder);
@@ -233,9 +243,13 @@ namespace FakeNamespace
         {
             modelBuilder.Entity<CategoryRenamed>(entity =>
             {
+                entity.HasKey(e => e.CategoryIdRenamed);
+
                 entity.ToTable(""Category"");
 
                 entity.HasComment(""A category of products"");
+
+                entity.Property(e => e.CategoryIdRenamed).HasColumnName(""CategoryId"");
 
                 entity.Property(e => e.CategoryNameRenamed)
                     .HasColumnName(""CategoryName"")
@@ -246,9 +260,15 @@ namespace FakeNamespace
 
             modelBuilder.Entity<ProductRenamed>(entity =>
             {
+                entity.HasKey(e => e.ProductIdRenamed);
+
                 entity.ToTable(""Product"");
 
-                entity.HasIndex(e => e.CategoryId, ""IX_Product_CategoryId"");
+                entity.HasIndex(e => e.CategoryIdRenamed, ""IX_Product_CategoryId"");
+
+                entity.Property(e => e.ProductIdRenamed).HasColumnName(""ProductId"");
+
+                entity.Property(e => e.CategoryIdRenamed).HasColumnName(""CategoryId"");
 
                 entity.Property(e => e.ProductName)
                     .IsRequired()
@@ -264,7 +284,7 @@ namespace FakeNamespace
 
                 entity.HasOne(d => d.Category)
                     .WithMany(p => p.Product)
-                    .HasForeignKey(d => d.CategoryId);
+                    .HasForeignKey(d => d.CategoryIdRenamed);
             });
 
             OnModelCreatingPartial(modelBuilder);

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -53,6 +53,57 @@ namespace FakeNamespace
 ";
         }
 
+        private static class ExpectedEntitiesWithTransformMappings
+        {
+            public const string CategoryClass =
+@"using System;
+using System.Collections.Generic;
+
+namespace FakeNamespace
+{
+    /// <summary>
+    /// A category of products
+    /// </summary>
+    public partial class CategoryRenamed
+    {
+        public CategoryRenamed()
+        {
+            Products = new HashSet<ProductRenamed>();
+        }
+
+        public int CategoryId { get; set; }
+
+        /// <summary>
+        /// The name of a category
+        /// </summary>
+        public string CategoryNameRenamed { get; set; }
+
+        public virtual ICollection<ProductRenamed> Products { get; set; }
+    }
+}
+";
+
+            public const string ProductClass =
+@"using System;
+using System.Collections.Generic;
+
+namespace FakeNamespace
+{
+    public partial class ProductRenamed
+    {
+        public int ProductId { get; set; }
+        public string ProductName { get; set; }
+        public decimal? UnitPriceRenamed { get; set; }
+        public bool Discontinued { get; set; }
+        public byte[] RowVersion { get; set; }
+        public int? CategoryId { get; set; }
+
+        public virtual CategoryRenamed Category { get; set; }
+    }
+}
+";
+        }
+
         private static class ExpectedEntitiesWithAnnotations
         {
             public const string CategoryClass =
@@ -118,6 +169,77 @@ namespace FakeNamespace
         [ForeignKey(nameof(CategoryId))]
         [InverseProperty(""Products"")]
         public virtual Category Category { get; set; }
+    }
+}
+";
+        }
+
+        private static class ExpectedEntitiesWithAnnotationsAndTransformMappings
+        {
+            public const string CategoryClass =
+                @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace FakeNamespace
+{
+    /// <summary>
+    /// A category of products
+    /// </summary>
+    [Table(""Category"")]
+    public partial class CategoryRenamed
+    {
+        public CategoryRenamed()
+        {
+            Products = new HashSet<ProductRenamed>();
+        }
+
+        [Key]
+        public int CategoryId { get; set; }
+
+        /// <summary>
+        /// The name of a category
+        /// </summary>
+        [Required]
+        [Column(""CategoryName"")]
+        [StringLength(15)]
+        public string CategoryNameRenamed { get; set; }
+
+        [InverseProperty(nameof(ProductRenamed.Category))]
+        public virtual ICollection<ProductRenamed> Products { get; set; }
+    }
+}
+";
+
+            public const string ProductClass =
+                @"using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace FakeNamespace
+{
+    [Table(""Product"")]
+    [Index(nameof(CategoryId), Name = ""IX_Product_CategoryId"")]
+    public partial class ProductRenamed
+    {
+        [Key]
+        public int ProductId { get; set; }
+        [Required]
+        [StringLength(40)]
+        public string ProductName { get; set; }
+        [Column(""UnitPrice"", TypeName = ""money"")]
+        public decimal? UnitPriceRenamed { get; set; }
+        public bool Discontinued { get; set; }
+        public byte[] RowVersion { get; set; }
+        public int? CategoryId { get; set; }
+
+        [ForeignKey(nameof(CategoryId))]
+        [InverseProperty(""Products"")]
+        public virtual CategoryRenamed Category { get; set; }
     }
 }
 ";

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -71,7 +71,7 @@ namespace FakeNamespace
             Products = new HashSet<ProductRenamed>();
         }
 
-        public int CategoryId { get; set; }
+        public int CategoryIdRenamed { get; set; }
 
         /// <summary>
         /// The name of a category
@@ -91,12 +91,12 @@ namespace FakeNamespace
 {
     public partial class ProductRenamed
     {
-        public int ProductId { get; set; }
+        public int ProductIdRenamed { get; set; }
         public string ProductName { get; set; }
         public decimal? UnitPriceRenamed { get; set; }
         public bool Discontinued { get; set; }
         public byte[] RowVersion { get; set; }
-        public int? CategoryId { get; set; }
+        public int? CategoryIdRenamed { get; set; }
 
         public virtual CategoryRenamed Category { get; set; }
     }
@@ -197,7 +197,8 @@ namespace FakeNamespace
         }
 
         [Key]
-        public int CategoryId { get; set; }
+        [Column(""CategoryId"")]
+        public int CategoryIdRenamed { get; set; }
 
         /// <summary>
         /// The name of a category
@@ -227,7 +228,8 @@ namespace FakeNamespace
     public partial class ProductRenamed
     {
         [Key]
-        public int ProductId { get; set; }
+        [Column(""ProductId"")]
+        public int ProductIdRenamed { get; set; }
         [Required]
         [StringLength(40)]
         public string ProductName { get; set; }
@@ -235,9 +237,10 @@ namespace FakeNamespace
         public decimal? UnitPriceRenamed { get; set; }
         public bool Discontinued { get; set; }
         public byte[] RowVersion { get; set; }
-        public int? CategoryId { get; set; }
+        [Column(""CategoryId"")]
+        public int? CategoryIdRenamed { get; set; }
 
-        [ForeignKey(nameof(CategoryId))]
+        [ForeignKey(nameof(CategoryIdRenamed))]
         [InverseProperty(""Products"")]
         public virtual CategoryRenamed Category { get; set; }
     }

--- a/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
@@ -5,39 +5,27 @@ namespace Scaffolding.Handlebars.Tests.Helpers
 {
     public static class HandlebarsTransformers
     {
-        static Dictionary<string, string> entityTypeNameMappings = new Dictionary<string, string>(){
+        static readonly Dictionary<string, string> _entityTypeNameMappings = new(){
             {"Product","ProductRenamed"},
             {"Category","CategoryRenamed"}
         };
-        static Dictionary<string, string> entityPropertyNameMappings = new Dictionary<string, string>(){
+        static readonly Dictionary<string, string> _entityPropertyNameMappings = new(){
             {"UnitPrice","UnitPriceRenamed"},
             {"CategoryName","CategoryNameRenamed"}
         };
-        public static string MapEntityName(string entityName)
-        {
-            var nameOverride = string.Empty;
-            if (entityTypeNameMappings.TryGetValue(entityName, out nameOverride)) return nameOverride;
-            return entityName;
-        }
-        public static EntityPropertyInfo MapNavPropertyInfo(EntityPropertyInfo e)
-        {
-            return new EntityPropertyInfo(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
-        }
-        public static EntityPropertyInfo MapPropertyInfo(EntityPropertyInfo e)
-        {
-            return new EntityPropertyInfo(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
-        }
-        private static string MapPropertyTypeName(string propertyTypeName)
-        {
-            var propertyTypeNameOverride = string.Empty;
-            if (entityTypeNameMappings.TryGetValue(propertyTypeName, out propertyTypeNameOverride)) return propertyTypeNameOverride;
-            return propertyTypeName;
-        }
-        private static string MapPropertyName(string propertyName)
-        {
-            var propertyNameOverride = string.Empty;
-            if (entityPropertyNameMappings.TryGetValue(propertyName, out propertyNameOverride)) return propertyNameOverride;
-            return propertyName;
-        }
+        public static string MapEntityName(string entityName) =>
+            _entityTypeNameMappings.TryGetValue(entityName, out var nameOverride) ? nameOverride : entityName;
+
+        public static EntityPropertyInfo MapNavPropertyInfo(EntityPropertyInfo e) =>
+            new(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
+
+        public static EntityPropertyInfo MapPropertyInfo(EntityPropertyInfo e) =>
+            new(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
+
+        private static string MapPropertyTypeName(string propertyTypeName) =>
+            _entityTypeNameMappings.TryGetValue(propertyTypeName, out var propertyTypeNameOverride) ? propertyTypeNameOverride : propertyTypeName;
+
+        private static string MapPropertyName(string propertyName) =>
+            _entityPropertyNameMappings.TryGetValue(propertyName, out var propertyNameOverride) ? propertyNameOverride : propertyName;
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
@@ -1,0 +1,43 @@
+using EntityFrameworkCore.Scaffolding.Handlebars;
+using System.Collections.Generic;
+
+namespace Scaffolding.Handlebars.Tests.Helpers
+{
+    public static class HandlebarsTransformers
+    {
+        static Dictionary<string, string> entityTypeNameMappings = new Dictionary<string, string>(){
+            {"Product","ProductRenamed"},
+            {"Category","CategoryRenamed"}
+        };
+        static Dictionary<string, string> entityPropertyNameMappings = new Dictionary<string, string>(){
+            {"UnitPrice","UnitPriceRenamed"},
+            {"CategoryName","CategoryNameRenamed"}
+        };
+        public static string MapEntityName(string entityName)
+        {
+            var nameOverride = string.Empty;
+            if (entityTypeNameMappings.TryGetValue(entityName, out nameOverride)) return nameOverride;
+            return entityName;
+        }
+        public static EntityPropertyInfo MapNavPropertyInfo(EntityPropertyInfo e)
+        {
+            return new EntityPropertyInfo(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
+        }
+        public static EntityPropertyInfo MapPropertyInfo(EntityPropertyInfo e)
+        {
+            return new EntityPropertyInfo(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
+        }
+        private static string MapPropertyTypeName(string propertyTypeName)
+        {
+            var propertyTypeNameOverride = string.Empty;
+            if (entityTypeNameMappings.TryGetValue(propertyTypeName, out propertyTypeNameOverride)) return propertyTypeNameOverride;
+            return propertyTypeName;
+        }
+        private static string MapPropertyName(string propertyName)
+        {
+            var propertyNameOverride = string.Empty;
+            if (entityPropertyNameMappings.TryGetValue(propertyName, out propertyNameOverride)) return propertyNameOverride;
+            return propertyName;
+        }
+    }
+}

--- a/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
@@ -5,13 +5,17 @@ namespace Scaffolding.Handlebars.Tests.Helpers
 {
     public static class HandlebarsTransformers
     {
-        static readonly Dictionary<string, string> _entityTypeNameMappings = new(){
-            {"Product","ProductRenamed"},
-            {"Category","CategoryRenamed"}
+        static readonly Dictionary<string, string> _entityTypeNameMappings = new()
+        {
+            { "Product","ProductRenamed" },
+            { "Category","CategoryRenamed" }
         };
-        static readonly Dictionary<string, string> _entityPropertyNameMappings = new(){
-            {"UnitPrice","UnitPriceRenamed"},
-            {"CategoryName","CategoryNameRenamed"}
+        static readonly Dictionary<string, string> _entityPropertyNameMappings = new()
+        {
+            { "ProductId", "ProductIdRenamed" },
+            { "UnitPrice","UnitPriceRenamed"},
+            { "CategoryId", "CategoryIdRenamed" },
+            { "CategoryName","CategoryNameRenamed" }
         };
         public static string MapEntityName(string entityName) =>
             _entityTypeNameMappings.TryGetValue(entityName, out var nameOverride) ? nameOverride : entityName;


### PR DESCRIPTION
When using Transform mappings, and UseDataAnnotations=false, provide .ToTable and .HasColumnName methods in the generated context when table and column names are different to the entity and property names.

When using Transform mappings, and UseDataAnnotations=true, use ColumnAttribute in generated entities and do not use .ToTable and .HasColumnName methods in the context. 

Closes #188.
