### PR TITLE
Call TransformContextFileName during context generation.

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -34,6 +34,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         private string _modelNamespace;
 
         /// <summary>
+        /// Service for transforming context definitions
+        /// </summary>
+        protected IContextTransformationService ContextTransformationService { get; }
+
+        /// <summary>
         /// CSharp helper.
         /// </summary>
         protected ICSharpHelper CSharpHelper { get; }
@@ -82,12 +87,14 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <param name="annotationCodeGenerator">Annotation code generator.</param>
         /// <param name="cSharpHelper">CSharp helper.</param>
         /// <param name="dbContextTemplateService">Template service for DbContext generator.</param>
+        /// <param name="contextTransformationService">Template service for DbContext generator.</param>
         /// <param name="entityTypeTransformationService">Service for transforming entity definitions.</param>
         /// <param name="options">Handlebars scaffolding options.</param>
         public HbsCSharpDbContextGenerator(
             [NotNull] IProviderConfigurationCodeGenerator providerConfigurationCodeGenerator,
             [NotNull] IAnnotationCodeGenerator annotationCodeGenerator,
             [NotNull] IDbContextTemplateService dbContextTemplateService,
+            [NotNull] IContextTransformationService contextTransformationService,
             [NotNull] IEntityTypeTransformationService entityTypeTransformationService,
             [NotNull] ICSharpHelper cSharpHelper,
             [NotNull] IOptions<HandlebarsScaffoldingOptions> options)
@@ -97,6 +104,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             AnnotationCodeGenerator = annotationCodeGenerator;
             CSharpHelper = cSharpHelper;
             DbContextTemplateService = dbContextTemplateService;
+            ContextTransformationService = contextTransformationService;
             EntityTypeTransformationService = entityTypeTransformationService;
             _options = options;
         }
@@ -118,7 +126,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             string modelNamespace, bool useDataAnnotations, bool useNullableReferenceTypes, bool suppressConnectionStringWarning, bool suppressOnConfiguring)
         {
             Check.NotNull(model, nameof(model));
-
+			ContextTransformationService.TransformContextFileName(contextName + ".cs");
             if (!string.IsNullOrEmpty(modelNamespace) && string.CompareOrdinal(contextNamespace, modelNamespace) != 0)
                 _modelNamespace = modelNamespace;
 

--- a/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
@@ -453,6 +453,7 @@ namespace Scaffolding.Handlebars.Tests
                         provider.GetRequiredService<IProviderConfigurationCodeGenerator>(),
                         provider.GetRequiredService<IAnnotationCodeGenerator>(),
                         provider.GetRequiredService<IDbContextTemplateService>(),
+                        provider.GetRequiredService<IContextTransformationService>(),
                         provider.GetRequiredService<IEntityTypeTransformationService>(),
                         provider.GetRequiredService<ICSharpHelper>(),
                         provider.GetRequiredService<IOptions<HandlebarsScaffoldingOptions>>());

--- a/test/Scaffolding.Handlebars.Tests/HbsTypeScriptScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsTypeScriptScaffoldingGeneratorTests.cs
@@ -371,6 +371,7 @@ namespace Scaffolding.Handlebars.Tests
                         provider.GetRequiredService<IProviderConfigurationCodeGenerator>(),
                         provider.GetRequiredService<IAnnotationCodeGenerator>(),
                         provider.GetRequiredService<IDbContextTemplateService>(),
+                        provider.GetRequiredService<IContextTransformationService>(),
                         provider.GetRequiredService<IEntityTypeTransformationService>(),
                         provider.GetRequiredService<ICSharpHelper>(),
                         provider.GetRequiredService<IOptions<HandlebarsScaffoldingOptions>>());


### PR DESCRIPTION
When writing the design time transformer class a JSON lookup file is used mappings:-

		"Name": "EntitiesOne:Aircraft",
		"NameOverride": "MyAircraft",
		"Mappings": [
			{
				"Name": "Livery",
				"NameMapping": "MyLivery"
			}
		]
To correctly select the mappings:-

- Entity Name Mappings require the context:entityname
- PropertyName Mappings require context:entityname:propertyname


So need the context and need the TransformContextFileName method to be called early on in my Transformer class so the context can be stored locally. Currently it is only called when the model is generated in the HbsCSharpModelGenerator.

Closes #198.

