### PR TITLE
Fix ambiguous method AddHandlebarsTransformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,20 +256,20 @@ public class ScaffoldingDesignTimeServices : IDesignTimeServices
 
             // Add Handlebars transformer for Country property
             services.AddHandlebarsTransformers(
-                propertyTransformer: (e, p) =>
+                propertyTransformer: p =>
                     p.PropertyName == "Country"
                         ? new EntityPropertyInfo("Country?", p.PropertyName, false)
                         : new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
 
             // Add Handlebars transformer for Id property
-            //services.AddHandlebarsTransformers(
+            //services.AddHandlebarsTransformers2(
             //    propertyTransformer: (e, p) =>
             //        $"{e.Name}Id" == p.PropertyName
             //            ? new EntityPropertyInfo(p.PropertyType, "Id", false)
             //            : new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
 
             // Add optional Handlebars transformers
-            //services.AddHandlebarsTransformers(
+            //services.AddHandlebarsTransformers2(
             //    entityTypeNameTransformer: n => n + "Foo",
             //    entityFileNameTransformer: n => n + "Foo",
             //    constructorTransformer: (e, p) => new EntityPropertyInfo(p.PropertyType + "Foo", p.PropertyName + "Foo"),

--- a/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
+++ b/sample/ScaffoldingSample/ScaffoldingDesignTimeServices.cs
@@ -56,20 +56,20 @@ namespace ScaffoldingSample
 
             // Add Handlebars transformer for Country property
             services.AddHandlebarsTransformers(
-                propertyTransformer: (e, p) =>
+                propertyTransformer: p =>
                     p.PropertyName == "Country"
                         ? new EntityPropertyInfo("Country?", p.PropertyName, false)
                         : new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
 
             // Add Handlebars transformer for Id property
-            //services.AddHandlebarsTransformers(
+            //services.AddHandlebarsTransformers2(
             //    propertyTransformer: (e, p) =>
             //        $"{e.Name}Id" == p.PropertyName
             //            ? new EntityPropertyInfo(p.PropertyType, "Id", false)
             //            : new EntityPropertyInfo(p.PropertyType, p.PropertyName, p.PropertyIsNullable));
 
             // Add optional Handlebars transformers
-            //services.AddHandlebarsTransformers(
+            //services.AddHandlebarsTransformers2(
             //    entityTypeNameTransformer: n => n + "Foo",
             //    entityFileNameTransformer: n => n + "Foo",
             //    constructorTransformer: (e, p) => new EntityPropertyInfo(p.PropertyType + "Foo", p.PropertyName + "Foo"),

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
     <Authors>Tony Sneed</Authors>
     <Company>Tony Sneed</Company>
     <Title>Entity Framework Core Scaffolding with Handlebars</Title>
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>scaffolding reverse-engineer entity-framework-core handlebars</PackageTags>
-    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v6.0.0</PackageReleaseNotes>
+    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v6.0.1</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <IncludeSource>true</IncludeSource>
     <SignAssembly>true</SignAssembly>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -230,7 +230,7 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="navPropertyTransformer">Navigation property name transformer.</param>
         /// <param name="contextFileNameTransformer">Context file name transformer.</param>
         /// <returns>The same service collection so that multiple calls can be chained.</returns>
-        public static IServiceCollection AddHandlebarsTransformers(this IServiceCollection services,
+        public static IServiceCollection AddHandlebarsTransformers2(this IServiceCollection services,
             Func<string, string> entityTypeNameTransformer = null,
             Func<string, string> entityFileNameTransformer = null,
             Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,


### PR DESCRIPTION
Rename overloaded `AddHandlebarsTransformers` to `AddHandlebarsTransformers2`.

Update `HbsCSharpEntityTypeGenerator.GenerateForeignKeyAttribute` to avoid generating FK attribute when key has been transformed.

Closes #201.