### PR TITLE
[Fix] HasKey Reference Left Out with Non-Conventional Key Property

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.0.2</Version>
+    <Version>6.0.3</Version>
     <Authors>Tony Sneed</Authors>
     <Company>Tony Sneed</Company>
     <Title>Entity Framework Core Scaffolding with Handlebars</Title>
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>scaffolding reverse-engineer entity-framework-core handlebars</PackageTags>
-    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v6.0.2</PackageReleaseNotes>
+    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v6.0.3</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <IncludeSource>true</IncludeSource>
     <SignAssembly>true</SignAssembly>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -506,7 +506,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         KeyDiscoveryConvention.DiscoverKeyProperties(
                             concreteKey.DeclaringEntityType,
                             concreteKey.DeclaringEntityType.GetProperties()))
-                    && UseDataAnnotations || !propertyNameOverriden)
+                    && !propertyNameOverriden)
                 {
                     return;
                 }

--- a/test/Scaffolding.Handlebars.Tests/Contexts/NorthwindDbContext.cs
+++ b/test/Scaffolding.Handlebars.Tests/Contexts/NorthwindDbContext.cs
@@ -11,6 +11,7 @@ namespace Scaffolding.Handlebars.Tests.Contexts
 
         public DbSet<Category> Categories { get; set; }
         public DbSet<Product> Products { get; set; }
+        public DbSet<Customer> Customers { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -18,6 +19,10 @@ namespace Scaffolding.Handlebars.Tests.Contexts
                 .HasComment("A category of products")
                 .Property(category => category.CategoryName)
                     .HasComment("The name of a category");
+            modelBuilder.Entity<Customer>(entity =>
+            {
+                entity.Property(e => e.CustomerKey).IsFixedLength();
+            });
         }
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedContexts.cs
@@ -16,6 +16,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<Category> Categories { get; set; }
+        public virtual DbSet<Customer> Customers { get; set; }
         public virtual DbSet<Product> Products { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -43,6 +44,27 @@ namespace FakeNamespace
                     .IsRequired()
                     .HasMaxLength(15)
                     .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<Customer>(entity =>
+            {
+                entity.HasKey(e => e.CustomerKey);
+
+                entity.ToTable(""Customer"");
+
+                entity.Property(e => e.CustomerKey)
+                    .HasMaxLength(5)
+                    .IsFixedLength();
+
+                entity.Property(e => e.City).HasMaxLength(15);
+
+                entity.Property(e => e.CompanyName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.ContactName).HasMaxLength(30);
+
+                entity.Property(e => e.Country).HasMaxLength(15);
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -87,6 +109,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<CategoryRenamed> Category { get; set; }
+        public virtual DbSet<CustomerRenamed> Customer { get; set; }
         public virtual DbSet<ProductRenamed> Product { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -119,6 +142,27 @@ namespace FakeNamespace
                     .IsRequired()
                     .HasMaxLength(15)
                     .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<CustomerRenamed>(entity =>
+            {
+                entity.HasKey(e => e.CustomerKey);
+
+                entity.ToTable(""Customer"");
+
+                entity.Property(e => e.CustomerKey)
+                    .HasMaxLength(5)
+                    .IsFixedLength();
+
+                entity.Property(e => e.City).HasMaxLength(15);
+
+                entity.Property(e => e.CompanyName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.ContactName).HasMaxLength(30);
+
+                entity.Property(e => e.Country).HasMaxLength(15);
             });
 
             modelBuilder.Entity<ProductRenamed>(entity =>
@@ -171,6 +215,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<Category> Categories { get; set; }
+        public virtual DbSet<Customer> Customers { get; set; }
         public virtual DbSet<Product> Products { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -189,6 +234,27 @@ namespace FakeNamespace
                     .IsRequired()
                     .HasMaxLength(15)
                     .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<Customer>(entity =>
+            {
+                entity.HasKey(e => e.CustomerKey);
+
+                entity.ToTable(""Customer"");
+
+                entity.Property(e => e.CustomerKey)
+                    .HasMaxLength(5)
+                    .IsFixedLength();
+
+                entity.Property(e => e.City).HasMaxLength(15);
+
+                entity.Property(e => e.CompanyName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.ContactName).HasMaxLength(30);
+
+                entity.Property(e => e.Country).HasMaxLength(15);
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -233,6 +299,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<CategoryRenamed> Category { get; set; }
+        public virtual DbSet<CustomerRenamed> Customer { get; set; }
         public virtual DbSet<ProductRenamed> Product { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -256,6 +323,27 @@ namespace FakeNamespace
                     .IsRequired()
                     .HasMaxLength(15)
                     .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<CustomerRenamed>(entity =>
+            {
+                entity.HasKey(e => e.CustomerKey);
+
+                entity.ToTable(""Customer"");
+
+                entity.Property(e => e.CustomerKey)
+                    .HasMaxLength(5)
+                    .IsFixedLength();
+
+                entity.Property(e => e.City).HasMaxLength(15);
+
+                entity.Property(e => e.CompanyName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.ContactName).HasMaxLength(30);
+
+                entity.Property(e => e.Country).HasMaxLength(15);
             });
 
             modelBuilder.Entity<ProductRenamed>(entity =>
@@ -308,6 +396,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<Category> Categories { get; set; }
+        public virtual DbSet<Customer> Customers { get; set; }
         public virtual DbSet<Product> Products { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -330,6 +419,11 @@ namespace FakeNamespace
                 entity.HasComment(""A category of products"");
 
                 entity.Property(e => e.CategoryName).HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<Customer>(entity =>
+            {
+                entity.Property(e => e.CustomerKey).IsFixedLength();
             });
 
             modelBuilder.Entity<Product>(entity =>
@@ -360,6 +454,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<CategoryRenamed> Category { get; set; }
+        public virtual DbSet<CustomerRenamed> Customer { get; set; }
         public virtual DbSet<ProductRenamed> Product { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -382,6 +477,11 @@ namespace FakeNamespace
                 entity.HasComment(""A category of products"");
 
                 entity.Property(e => e.CategoryNameRenamed).HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<CustomerRenamed>(entity =>
+            {
+                entity.Property(e => e.CustomerKey).IsFixedLength();
             });
 
             modelBuilder.Entity<ProductRenamed>(entity =>

--- a/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedTypeScriptContexts.cs
@@ -16,6 +16,7 @@ namespace FakeNamespace
     public partial class FakeDbContext : DbContext
     {
         public virtual DbSet<Category> Categories { get; set; }
+        public virtual DbSet<Customer> Customers { get; set; }
         public virtual DbSet<Product> Products { get; set; }
 
         public FakeDbContext(DbContextOptions<FakeDbContext> options) : base(options)
@@ -43,6 +44,27 @@ namespace FakeNamespace
                     .IsRequired()
                     .HasMaxLength(15)
                     .HasComment(""The name of a category"");
+            });
+
+            modelBuilder.Entity<Customer>(entity =>
+            {
+                entity.HasKey(e => e.CustomerKey);
+
+                entity.ToTable(""Customer"");
+
+                entity.Property(e => e.CustomerKey)
+                    .HasMaxLength(5)
+                    .IsFixedLength();
+
+                entity.Property(e => e.City).HasMaxLength(15);
+
+                entity.Property(e => e.CompanyName)
+                    .IsRequired()
+                    .HasMaxLength(40);
+
+                entity.Property(e => e.ContactName).HasMaxLength(30);
+
+                entity.Property(e => e.Country).HasMaxLength(15);
             });
 
             modelBuilder.Entity<Product>(entity =>

--- a/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsCSharpScaffoldingGeneratorTests.cs
@@ -526,9 +526,11 @@ namespace Scaffolding.Handlebars.Tests
             // Assert
             var expectedContextPath = Path.Combine(directory.Path, "Contexts", Constants.Files.CSharpFiles.DbContextFile);
             var expectedCategoryPath = Path.Combine(directory.Path, "Models", Constants.Files.CSharpFiles.CategoryFile);
+            var expectedCustomerPath = Path.Combine(directory.Path, "Models", Constants.Files.CSharpFiles.CustomerFile);
             var expectedProductPath = Path.Combine(directory.Path, "Models", Constants.Files.CSharpFiles.ProductFile);
             Assert.Equal(expectedCategoryPath, result.AdditionalFiles[0]);
-            Assert.Equal(expectedProductPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedCustomerPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedProductPath, result.AdditionalFiles[2]);
             Assert.False(File.Exists(expectedContextPath));
         }
 
@@ -561,10 +563,12 @@ namespace Scaffolding.Handlebars.Tests
             // Assert
             var expectedContextPath = Path.Combine(directory.Path, "Contexts", $"{filenamePrefix}{Constants.Files.CSharpFiles.DbContextFile}");
             var expectedCategoryPath = Path.Combine(directory.Path, "Models", $"{filenamePrefix}{Constants.Files.CSharpFiles.CategoryFile}");
+            var expectedCustomerPath = Path.Combine(directory.Path, "Models", $"{filenamePrefix}{Constants.Files.CSharpFiles.CustomerFile}");
             var expectedProductPath = Path.Combine(directory.Path, "Models", $"{filenamePrefix}{ Constants.Files.CSharpFiles.ProductFile}");
             Assert.Equal(expectedContextPath, result.ContextFile);
             Assert.Equal(expectedCategoryPath, result.AdditionalFiles[0]);
-            Assert.Equal(expectedProductPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedCustomerPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedProductPath, result.AdditionalFiles[2]);
         }
 
         [Fact]
@@ -595,10 +599,12 @@ namespace Scaffolding.Handlebars.Tests
             // Assert
             var expectedContextPath = Path.Combine(directory.Path, "Contexts", Constants.Files.CSharpFiles.DbContextFile);
             var expectedCategoryPath = Path.Combine(directory.Path, "Models", Constants.Files.CSharpFiles.CategoryFile);
+            var expectedCustomerPath = Path.Combine(directory.Path, "Models", Constants.Files.CSharpFiles.CustomerFile);
             var expectedProductPath = Path.Combine(directory.Path, "Models", Constants.Files.CSharpFiles.ProductFile);
             Assert.Equal(expectedContextPath, result.ContextFile);
             Assert.Equal(expectedCategoryPath, result.AdditionalFiles[0]);
-            Assert.Equal(expectedProductPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedCustomerPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedProductPath, result.AdditionalFiles[2]);
         }
 
         private IReverseEngineerScaffolder CreateScaffolder(ReverseEngineerOptions revEngOptions, bool useEntityNameMappings)
@@ -611,7 +617,7 @@ namespace Scaffolding.Handlebars.Tests
         }
 
         private IReverseEngineerScaffolder CreateScaffolder(ReverseEngineerOptions revEngOptions,
-            Action<HandlebarsScaffoldingOptions> configureOptions,bool useEntityTransformMappings = false,
+            Action<HandlebarsScaffoldingOptions> configureOptions, bool useEntityTransformMappings = false,
             string filenamePrefix = null, bool useAltTemplates = false)
         {
             HandlebarsLib.Configuration.NoEscape = true;
@@ -709,7 +715,8 @@ namespace Scaffolding.Handlebars.Tests
                 || options == ReverseEngineerOptions.DbContextAndEntities)
             {
                 generatedFiles.Add(Constants.Files.CSharpFiles.CategoryFile, model.AdditionalFiles[0].Code);
-                generatedFiles.Add(Constants.Files.CSharpFiles.ProductFile, model.AdditionalFiles[1].Code);
+                generatedFiles.Add(Constants.Files.CSharpFiles.CustomerFile, model.AdditionalFiles[1].Code);
+                generatedFiles.Add(Constants.Files.CSharpFiles.ProductFile, model.AdditionalFiles[2].Code);
             }
 
             return generatedFiles;

--- a/test/Scaffolding.Handlebars.Tests/HbsTypeScriptScaffoldingGeneratorTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/HbsTypeScriptScaffoldingGeneratorTests.cs
@@ -275,9 +275,11 @@ namespace Scaffolding.Handlebars.Tests
             // Assert
             var expectedContextPath = Path.Combine(directory.Path, "Contexts", Constants.Files.TypeScriptFiles.DbContextFile);
             var expectedCategoryPath = Path.Combine(directory.Path, "Models", Constants.Files.TypeScriptFiles.CategoryFile);
+            var expectedCustomerPath = Path.Combine(directory.Path, "Models", Constants.Files.TypeScriptFiles.CustomerFile);
             var expectedProductPath = Path.Combine(directory.Path, "Models", Constants.Files.TypeScriptFiles.ProductFile);
             Assert.Equal(expectedCategoryPath, result.AdditionalFiles[0]);
-            Assert.Equal(expectedProductPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedCustomerPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedProductPath, result.AdditionalFiles[2]);
             Assert.False(File.Exists(expectedContextPath));
         }
 
@@ -310,10 +312,12 @@ namespace Scaffolding.Handlebars.Tests
             // Assert
             var expectedContextPath = Path.Combine(directory.Path, "Contexts", $"{filenamePrefix}{Constants.Files.TypeScriptFiles.DbContextFile}");
             var expectedCategoryPath = Path.Combine(directory.Path, "Models", $"{filenamePrefix}{Constants.Files.TypeScriptFiles.CategoryFile}");
+            var expectedCustomerPath = Path.Combine(directory.Path, "Models", $"{filenamePrefix}{Constants.Files.TypeScriptFiles.CustomerFile}");
             var expectedProductPath = Path.Combine(directory.Path, "Models", $"{filenamePrefix}{ Constants.Files.TypeScriptFiles.ProductFile}");
             Assert.Equal(expectedContextPath, result.ContextFile);
             Assert.Equal(expectedCategoryPath, result.AdditionalFiles[0]);
-            Assert.Equal(expectedProductPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedCustomerPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedProductPath, result.AdditionalFiles[2]);
         }
 
         [Fact]
@@ -344,10 +348,12 @@ namespace Scaffolding.Handlebars.Tests
             // Assert
             var expectedContextPath = Path.Combine(directory.Path, "Contexts", Constants.Files.TypeScriptFiles.DbContextFile);
             var expectedCategoryPath = Path.Combine(directory.Path, "Models", Constants.Files.TypeScriptFiles.CategoryFile);
+            var expectedCustomerPath = Path.Combine(directory.Path, "Models", Constants.Files.TypeScriptFiles.CustomerFile);
             var expectedProductPath = Path.Combine(directory.Path, "Models", Constants.Files.TypeScriptFiles.ProductFile);
             Assert.Equal(expectedContextPath, result.ContextFile);
             Assert.Equal(expectedCategoryPath, result.AdditionalFiles[0]);
-            Assert.Equal(expectedProductPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedCustomerPath, result.AdditionalFiles[1]);
+            Assert.Equal(expectedProductPath, result.AdditionalFiles[2]);
         }
 
         private IReverseEngineerScaffolder CreateScaffolder(ReverseEngineerOptions options, string filenamePrefix = null)
@@ -437,7 +443,8 @@ namespace Scaffolding.Handlebars.Tests
                 || options == ReverseEngineerOptions.DbContextAndEntities)
             {
                 generatedFiles.Add(Constants.Files.TypeScriptFiles.CategoryFile, model.AdditionalFiles[0].Code);
-                generatedFiles.Add(Constants.Files.TypeScriptFiles.ProductFile, model.AdditionalFiles[1].Code);
+                generatedFiles.Add(Constants.Files.TypeScriptFiles.CustomerFile, model.AdditionalFiles[1].Code);
+                generatedFiles.Add(Constants.Files.TypeScriptFiles.ProductFile, model.AdditionalFiles[2].Code);
             }
 
             return generatedFiles;

--- a/test/Scaffolding.Handlebars.Tests/Helpers/Constants.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/Constants.cs
@@ -48,12 +48,14 @@
             {
                 public const string DbContextFile = Parameters.ContextName + ".cs";
                 public const string CategoryFile = "Category.cs";
+                public const string CustomerFile = "Customer.cs";
                 public const string ProductFile = "Product.cs";
             }
             public static class TypeScriptFiles
             {
                 public const string DbContextFile = Parameters.ContextName + ".cs";
                 public const string CategoryFile = "Category.ts";
+                public const string CustomerFile = "Customer.ts";
                 public const string ProductFile = "Product.ts";
             }
         }

--- a/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
@@ -8,7 +8,8 @@ namespace Scaffolding.Handlebars.Tests.Helpers
         static readonly Dictionary<string, string> _entityTypeNameMappings = new()
         {
             { "Product","ProductRenamed" },
-            { "Category","CategoryRenamed" }
+            { "Customer","CustomerRenamed" },
+            { "Category", "CategoryRenamed" }
         };
         static readonly Dictionary<string, string> _entityPropertyNameMappings = new()
         {

--- a/test/Scaffolding.Handlebars.Tests/Models/Customer.cs
+++ b/test/Scaffolding.Handlebars.Tests/Models/Customer.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Scaffolding.Handlebars.Tests.Models
+{
+    [Table("Customer")]
+    public partial class Customer
+    {
+        [Key]
+        [StringLength(5)]
+        public string CustomerKey { get; set; }
+        [Required]
+        [StringLength(40)]
+        public string CompanyName { get; set; }
+        [StringLength(30)]
+        public string ContactName { get; set; }
+        [StringLength(15)]
+        public string City { get; set; }
+        [StringLength(15)]
+        public string Country { get; set; }
+    }
+}


### PR DESCRIPTION
Add HasHey to context when key is non-conventional.

Closes #203.