### PR TITLE
Simple glob/wildcard matching of table names

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ public partial class Product
 
 ## Excluded Tables
 
-You can optionally exclude certain tables from code generation. These may also be qualified by schema name.
+You can optionally exclude certain tables from code generation. These may also be qualified by schema name. Simple pattern matching, where "*" means any sequence
+and "?" means a single character is supported.
 
 ```csharp
 services.AddHandlebarsScaffolding(options =>
 {
     // Exclude some tables
-    options.ExcludedTables = new List<string> { "dbo.Territory" };
+    options.ExcludedTables = new List<string> { "dbo.Territory", "temp.*", "*.Employee" };
 });
 ```
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -806,8 +806,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             sb.AppendLine();
 
-            if (_options.Value.ExcludedTables != null
-                && _options.Value.ExcludedTables.Contains(skipNavigation.Inverse.ForeignKey.PrincipalEntityType.Name))
+            if (Helpers.TableExcluder.IsExcluded(_options.Value, skipNavigation.Inverse.ForeignKey.PrincipalEntityType))
                 return;
 
             var inverse = skipNavigation.Inverse;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/Helpers/TableExcluder.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/Helpers/TableExcluder.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace EntityFrameworkCore.Scaffolding.Handlebars.Helpers
+{
+    internal static class TableExcluder
+    {
+        public static bool IsExcluded(HandlebarsScaffoldingOptions options, IEntityType type)
+        {
+            if (options?.ExcludedTables?.Any() == true)
+            {
+                var schema = type.GetSchema() ?? type.GetViewSchema();
+                var table = type.GetTableName() ?? type.GetViewName();
+
+                var name = $"{schema}.{table}";
+
+                foreach (var exclusion in options?.ExcludedTables)
+                {
+                    // For backwards compatibility, if there is no ".", then we'll assume it is a table/view to be exluded
+                    // and add the schema wildcard
+                    var pattern = exclusion.Contains('.')
+                        ? exclusion
+                        : $"*.{exclusion}";
+
+                    // Simple glob emulation, credits to:
+                    // https://stackoverflow.com/questions/188892/glob-pattern-matching-in-net
+                    pattern = "^" + Regex.Escape(pattern).Replace(@"\*", ".*").Replace(@"\?", ".") + "$";
+                    if (Regex.IsMatch(name, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeExtensions.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using System.Linq;
 using System.Collections.Generic;
-using System.Linq;
-using EntityFrameworkCore.Scaffolding.Handlebars.Internal;
-using Microsoft.EntityFrameworkCore;
+
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EntityFrameworkCore.Scaffolding.Handlebars
@@ -20,23 +18,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <returns>Filtered set of navigations for scaffolding.</returns>
         public static IEnumerable<INavigation> GetScaffoldNavigations(this IEntityType entityType, HandlebarsScaffoldingOptions options)
         {
-            var result = new List<INavigation>();
-            var navigations = entityType.GetNavigations();
-            var excludedTables = GetExcludedTables(options);
-
-            foreach (var nav in navigations)
-            {
-                var schema = nav.TargetEntityType.GetSchema();
-                var table = nav.TargetEntityType.GetTableName();
-                if (!excludedTables.Any(e =>
-                    (!options.EnableSchemaFolders && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase))
-                    || string.Equals(schema, e.Schema, StringComparison.OrdinalIgnoreCase)
-                       && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase)))
-                {
-                    result.Add(nav);
-                }
-            }
-            return result;
+            return entityType
+                .GetNavigations()
+                .Where(nav => !Helpers.TableExcluder.IsExcluded(options, nav.TargetEntityType))
+                .ToList();
         }
 
         /// <summary>
@@ -47,23 +32,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <returns>Filtered set of navigations for scaffolding.</returns>
         public static IEnumerable<ISkipNavigation> GetScaffoldSkipNavigations(this IEntityType entityType, HandlebarsScaffoldingOptions options)
         {
-            var result = new List<ISkipNavigation>();
-            var navigations = entityType.GetSkipNavigations();
-            var excludedTables = GetExcludedTables(options);
-
-            foreach (var nav in navigations)
-            {
-                var schema = nav.TargetEntityType.GetSchema();
-                var table = nav.TargetEntityType.GetTableName();
-                if (!excludedTables.Any(e =>
-                    (!options.EnableSchemaFolders && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase))
-                    || string.Equals(schema, e.Schema, StringComparison.OrdinalIgnoreCase)
-                       && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase)))
-                {
-                    result.Add(nav);
-                }
-            }
-            return result;
+            return entityType
+                .GetSkipNavigations()
+                .Where(nav => !Helpers.TableExcluder.IsExcluded(options, nav.TargetEntityType))
+                .ToList();
         }
 
         /// <summary>
@@ -74,31 +46,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <returns>Filtered set of foreign keys for scaffolding.</returns>
         public static IEnumerable<IForeignKey> GetScaffoldForeignKeys(this IEntityType entityType, HandlebarsScaffoldingOptions options)
         {
-            var result = new List<IForeignKey>();
-            var foreignKeys = entityType.GetForeignKeys();
-            var excludedTables = GetExcludedTables(options);
-
-            foreach (var fk in foreignKeys)
-            {
-                var schema = fk.GetRelatedEntityType(fk.DeclaringEntityType).GetSchema();
-                var table = fk.GetRelatedEntityType(fk.DeclaringEntityType).GetTableName();
-                if (!excludedTables.Any(e =>
-                    (!options.EnableSchemaFolders && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase))
-                    || string.Equals(schema, e.Schema, StringComparison.OrdinalIgnoreCase)
-                       && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase)))
-                {
-                    result.Add(fk);
-                }
-            }
-            return result;
-        }
-
-        private static List<TableAndSchema> GetExcludedTables(HandlebarsScaffoldingOptions options)
-        {
-            var excludedTables = new List<TableAndSchema>();
-            if (options.ExcludedTables != null)
-                excludedTables = options.ExcludedTables.Select(t => new TableAndSchema(t)).ToList();
-            return excludedTables;
+            return entityType
+                .GetForeignKeys()
+                .Where(fk => !Helpers.TableExcluder.IsExcluded(options, fk.GetRelatedEntityType(fk.DeclaringEntityType)))
+                .ToList();
         }
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IModelExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IModelExtensions.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using System.Linq;
 using System.Collections.Generic;
-using System.Linq;
-using EntityFrameworkCore.Scaffolding.Handlebars.Internal;
-using Microsoft.EntityFrameworkCore;
+
 using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace EntityFrameworkCore.Scaffolding.Handlebars
@@ -20,28 +18,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         /// <returns>Filtered set of entity types for scaffolding.</returns>
         public static IEnumerable<IEntityType> GetScaffoldEntityTypes(this IModel model, HandlebarsScaffoldingOptions options)
         {
-            var entityTypes = model.GetEntityTypes();
-            if (options.ExcludedTables != null && options.ExcludedTables.Any())
-            {
-                // Handle matching view or table name for excludes.
-                var excludedTables = options.ExcludedTables.Select(t => new TableAndSchema(t)).ToList();
-                entityTypes = (from type in entityTypes
-                                let name = type.GetTableName()
-                                let isTable = !string.IsNullOrEmpty(name)
-                                let table = isTable
-                                    ? type.GetTableName()
-                                    : type.GetViewName()
-                                let schema = isTable
-                                    ? type.GetSchema()
-                                    : type.GetViewSchema()
-                               where !excludedTables.Any(e =>
-                                    (string.IsNullOrEmpty(e.Schema) ||
-                                     string.Equals(schema, e.Schema, StringComparison.OrdinalIgnoreCase))
-                                    && string.Equals(table, e.Table, StringComparison.OrdinalIgnoreCase))
-                                select type).ToList();
-            }
-
-            return entityTypes;
+            return model
+                .GetEntityTypes()
+                .Where(t => !Helpers.TableExcluder.IsExcluded(options, t))
+                .ToList();
         }
     }
 }

--- a/test/Scaffolding.Handlebars.Tests/IModelExtensionsTests.cs
+++ b/test/Scaffolding.Handlebars.Tests/IModelExtensionsTests.cs
@@ -114,5 +114,113 @@ namespace Scaffolding.Handlebars.Tests
             Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Category");
             Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
         }
+
+        [Fact]
+        public void IModel_Extensions_Should_Filter_EntityTypes_From_Options_By_TableName_Pattern()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+
+            builder.Entity<Category>()
+                .ToTable("Category", "dbo");
+
+            builder.Entity<Customer>()
+                .ToTable("Customer", "dbo");
+
+            builder.Entity<Product>()
+                .ToTable("Product", "prd");
+
+            var options = new HandlebarsScaffoldingOptions
+            {
+                ExcludedTables = new List<string> { "Prod*", "C??tomer" }
+            };
+
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
+
+            Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
+
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Product");
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Customer");
+        }
+
+        [Fact]
+        public void IModel_Extensions_Should_Filter_EntityTypes_From_Options_By_TableSchema_Pattern()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+
+            builder.Entity<Category>()
+                .ToTable("Category", "dbo");
+
+            builder.Entity<Customer>()
+                .ToTable("Customer", "dbo");
+
+            builder.Entity<Product>()
+                .ToTable("Product", "prd");
+
+            var options = new HandlebarsScaffoldingOptions
+            {
+                ExcludedTables = new List<string> { "dbo.*" }
+            };
+
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
+
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Category");
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Customer");
+
+            Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
+        }
+
+        [Fact]
+        public void IModel_Extensions_Should_Filter_EntityTypes_From_Options_By_ViewName_Pattern()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+
+            builder.Entity<Category>()
+                .ToView("Category", "dbo");
+
+            builder.Entity<Customer>()
+                .ToView("Customer", "dbo");
+
+            builder.Entity<Product>()
+                .ToView("Product", "prd");
+
+            var options = new HandlebarsScaffoldingOptions
+            {
+                ExcludedTables = new List<string> { "Prod*", "C??tomer" }
+            };
+
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
+
+            Assert.Contains(entityTypes, e => e.ClrType.Name == "Category");
+
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Product");
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Customer");
+        }
+
+        [Fact]
+        public void IModel_Extensions_Should_Filter_EntityTypes_From_Options_By_ViewSchema_Pattern()
+        {
+            var builder = new ModelBuilder(new ConventionSet());
+
+            builder.Entity<Category>()
+                .ToView("Category", "dbo");
+
+            builder.Entity<Customer>()
+                .ToView("Customer", "dbo");
+
+            builder.Entity<Product>()
+                .ToView("Product", "prd");
+
+            var options = new HandlebarsScaffoldingOptions
+            {
+                ExcludedTables = new List<string> { "dbo.*" }
+            };
+
+            var entityTypes = builder.FinalizeModel().GetScaffoldEntityTypes(options);
+
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Category");
+            Assert.DoesNotContain(entityTypes, e => e.ClrType.Name == "Customer");
+
+            Assert.Contains(entityTypes, e => e.ClrType.Name == "Product");
+        }
     }
 }


### PR DESCRIPTION
Add the ability to use a glob/wildcard syntax for tables/views to be excluded.

This will allow you to use a wildcard and do things like

- Customer (ignore the customer table/view, same as before)
- dbo.Customer (ignore the customer table/view in the dbo schema, same as before)
- dbo.* (ignore everything in dbo schema)
- Customer* (ignore any table/view that starts with Customer)
- db*.Custom* (ignore any table/view that starts with Custom in a schema that starts with db)
- db?.Custom?r
- *.Cust????

Existing unit tests work. Added a couple new ones.