### PR TITLE
Moved IsManyToManyJoinEntityType extension class

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/CodeTemplates/CSharpEntityType/Partials/Properties.hbs
@@ -8,7 +8,7 @@
 {{#each property-annotations}}
         {{{property-annotation}}}
 {{/each}}
-        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = null!;{{/unless}}{{/if}}
+        public {{property-type}} {{property-name}} { get; set; }{{#if nullable-reference-types }}{{#unless property-isnullable}} = null!;{{/unless}}{{else}}{{#if property-default-enum}} = {{property-default-enum}};{{/if}}{{/if}}
 {{/each}}
 {{#if nav-properties}}
 

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityPropertyInfo.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityPropertyInfo.cs
@@ -16,11 +16,16 @@
         /// <param name="propertyType">Property type.</param>
         /// <param name="propertyName">Property name.</param>
         /// <param name="propertyIsNullable">Property is nullable.</param>
-        public EntityPropertyInfo(string propertyType, string propertyName, bool? propertyIsNullable = null)
+        /// <param name="isEnumPropertyType">Is Enumeration Property Type</param>
+        /// <param name="propertyDefaultEnumValue">Default Enumeration Value. Format will be EnumName.EnumValue</param>
+        public EntityPropertyInfo(string propertyType, string propertyName, bool? propertyIsNullable = null
+            , bool? isEnumPropertyType = false, string propertyDefaultEnumValue = null)
         {
             PropertyType = propertyType;
             PropertyName = propertyName;
             PropertyIsNullable = propertyIsNullable;
+            IsEnumPropertyType = isEnumPropertyType;
+            PropertyDefaultEnumValue = propertyDefaultEnumValue;
         }
 
         /// <summary>
@@ -37,5 +42,16 @@
         /// Property is nullable.
         /// </summary>
         public bool? PropertyIsNullable { get; set; }
+        /// <summary>
+        /// Property Type is an Enumeration. 
+        /// Used in TransformPropertyTypeIfEnumaration
+        /// for Many to Many Virtual EntityTypes
+        /// </summary>
+        public bool? IsEnumPropertyType { get; set; }
+        /// <summary>
+        /// Property Default Value when using Enumarations
+        /// Format will be EnumName.EnumValue
+        /// </summary>
+        public string PropertyDefaultEnumValue { get; set; }
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -244,7 +244,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                     foreach (var entityType in model.GetScaffoldEntityTypes(_options.Value))
                     {
-                        if (IsManyToManyJoinEntityType(entityType))
+                        if (entityType.IsManyToManyJoinEntityType())
                         {
                             continue;
                         }
@@ -285,7 +285,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             foreach (var entityType in model.GetScaffoldEntityTypes(_options.Value))
             {
-                if (IsManyToManyJoinEntityType(entityType))
+                if (entityType.IsManyToManyJoinEntityType())
                 {
                     continue;
                 }
@@ -1204,30 +1204,5 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             => $".HasAnnotation({CSharpHelper.Literal(annotation.Name)}, " +
                $"{CSharpHelper.UnknownLiteral(annotation.Value)})";
 
-        private static bool IsManyToManyJoinEntityType(IEntityType entityType)
-        {
-            if (!entityType.GetNavigations().Any()
-                && !entityType.GetSkipNavigations().Any())
-            {
-                var primaryKey = entityType.FindPrimaryKey();
-                var properties = entityType.GetProperties().ToList();
-                var foreignKeys = entityType.GetForeignKeys().ToList();
-                if (primaryKey != null
-                    && primaryKey.Properties.Count > 1
-                    && foreignKeys.Count == 2
-                    && primaryKey.Properties.Count == properties.Count
-                    && foreignKeys[0].Properties.Count + foreignKeys[1].Properties.Count == properties.Count
-                    && !foreignKeys[0].Properties.Intersect(foreignKeys[1].Properties).Any()
-                    && foreignKeys[0].IsRequired
-                    && foreignKeys[1].IsRequired
-                    && !foreignKeys[0].IsUnique
-                    && !foreignKeys[1].IsUnique)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -266,6 +266,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     { "property-annotations",  PropertyAnnotationsData },
                     { "property-comment", _options?.Value?.GenerateComments == true ? GenerateComment(property.GetComment(), 2) : null },
                     { "property-isnullable", propertyIsNullable },
+                    { "property-isenum", false },
+                    { "property-default-enum", null },
                     { "nullable-reference-types", UseNullableReferenceTypes }
                 });
             }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -635,6 +635,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         {
             if (navigation == null) throw new ArgumentNullException(nameof(navigation));
 
+            if (navigation.ForeignKey.DeclaringEntityType.IsManyToManyJoinEntityType())
+            { 
+                return;
+            }
+
             GenerateForeignKeyAttribute(entityType, navigation);
             GenerateInversePropertyAttribute(entityType, navigation);
         }
@@ -696,6 +701,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         private void GenerateNavigationDataAnnotations(IEntityType entityType, ISkipNavigation navigation)
         {
             if (navigation == null) throw new ArgumentNullException(nameof(navigation));
+
+            if (navigation.ForeignKey.DeclaringEntityType.IsManyToManyJoinEntityType())
+            {
+                return;
+            }
 
             GenerateForeignKeyAttribute(entityType, navigation);
             GenerateInversePropertyAttribute(entityType, navigation);

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
@@ -190,6 +190,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     { "property-annotations",  new List<Dictionary<string, object>>() },
                     { "property-comment", property.GetComment() },
                     { "property-isnullable", property.IsNullable },
+                    { "property-isenum", false },
+                    { "property-default-enum", null },
                     { "nullable-reference-types", UseNullableReferenceTypes }
                 });
             }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -41,6 +41,25 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         string TransformNavPropertyName(IEntityType entityType, string propertyName, string propertyType);
 
         /// <summary>
+        /// Transforms the Property Type if it is an Enumeration.
+        /// Returns null when not an Enumeration
+        /// </summary>
+        /// <param name="entityType">Entity type.</param>
+        /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyType">Property type</param>
+        /// <returns>Transformed property name, null when not an Enumeration</returns>
+        public string TransformPropertyTypeIfEnumaration(IEntityType entityType, string propertyName, string propertyType);
+
+        /// <summary>
+        /// Transform Default Enum Value for a property
+        /// </summary>
+        /// <param name="entityType">Entity type.</param>
+        /// <param name="propertyName">Property name.</param>
+        /// <param name="propertyType">Property type</param>
+        /// <returns>Default Enumeration Value in format Format will be EnumName.EnumValue</returns>
+        public string TransformPropertyDefaultEnum(IEntityType entityType, string propertyName, string propertyType);
+
+        /// <summary>
         /// Transform entity type constructor.
         /// </summary>
         /// <param name="entityType">Entity type.</param>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/Internal/EntityTypeExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/Internal/EntityTypeExtensions.cs
@@ -21,4 +21,36 @@ public static class EntityTypeExtensions
     public static IEnumerable<IPropertyBase> GetPropertiesAndNavigations(
         this IEntityType entityType)
         => entityType.GetProperties().Concat<IPropertyBase>(entityType.GetNavigations());
+
+    /// <summary>
+    /// Determines if the given <see cref="IEntityType"/> is a join entity 
+    /// type for a many-to-many relationship where Entity would not be generated.
+    /// This is where only Key properties are present.
+    /// </summary>
+    /// <param name="entityType">Entity Type</param>
+    /// <returns></returns>
+    public static bool IsManyToManyJoinEntityType(this IEntityType entityType)
+    {
+        if (!entityType.GetNavigations().Any()
+            && !entityType.GetSkipNavigations().Any())
+        {
+            var primaryKey = entityType.FindPrimaryKey();
+            var properties = entityType.GetProperties().ToList();
+            var foreignKeys = entityType.GetForeignKeys().ToList();
+            if (primaryKey != null
+                && primaryKey.Properties.Count > 1
+                && foreignKeys.Count == 2
+                && primaryKey.Properties.Count == properties.Count
+                && foreignKeys[0].Properties.Count + foreignKeys[1].Properties.Count == properties.Count
+                && !foreignKeys[0].Properties.Intersect(foreignKeys[1].Properties).Any()
+                && foreignKeys[0].IsRequired
+                && foreignKeys[1].IsRequired
+                && !foreignKeys[0].IsUnique
+                && !foreignKeys[1].IsUnique)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Moved IsManyToManyJoinEntityType extension class. Use IsManyToManyJoinEntityType to prevent InverseProperty and ForeignKey Annotations from being generated in Virtual Tables.

Closes #240 
