### PR TITLE
Add IEntityType versions for Entity Type Name and Entity File Name transformers

### DIFF
--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpDbContextGenerator.cs
@@ -291,7 +291,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 }
 
                 var transformedEntityTypeName = GetEntityTypeName(
-                    entityType, EntityTypeTransformationService.TransformTypeEntityName(entityType.Name));
+                    entityType, EntityTypeTransformationService.TransformTypeEntityName(entityType, entityType.Name));
                 dbSets.Add(new Dictionary<string, object>
                 {
                     { "set-property-type", transformedEntityTypeName },
@@ -327,7 +327,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             if (!_entityTypeBuilderInitialized)
             {
                 var transformedEntityTypeName = GetEntityTypeName(
-                    entityType, EntityTypeTransformationService.TransformTypeEntityName(entityType.Name));
+                    entityType, EntityTypeTransformationService.TransformTypeEntityName(entityType, entityType.Name));
 
                 sb.AppendLine();
                 sb.AppendLine($"modelBuilder.Entity<{transformedEntityTypeName}>({EntityLambdaIdentifier} =>");
@@ -536,7 +536,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             var schema = entityType.GetSchema();
             var defaultSchema = entityType.Model.GetDefaultSchema();
 
-            var transformedTableName = EntityTypeTransformationService.TransformTypeEntityName(tableName);
+            var transformedTableName = EntityTypeTransformationService.TransformTypeEntityName(entityType, tableName);
             var tableNameVirtual = tableName != null && !tableName.Equals(transformedTableName);
 
             var explicitSchema = schema != null && schema != defaultSchema;
@@ -773,7 +773,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
             lines.Add(
                 $".{nameof(ReferenceReferenceBuilder.HasForeignKey)}"
-                + (foreignKey.IsUnique ? $"<{GetEntityTypeName(entityType, EntityTypeTransformationService.TransformTypeEntityName(entityType.Name))}>" : "")
+                + (foreignKey.IsUnique ? $"<{GetEntityTypeName(entityType, EntityTypeTransformationService.TransformTypeEntityName(entityType, entityType.Name))}>" : "")
                 + $"(d => {GenerateLambdaToKey(entityType, foreignKey.Properties, "d", EntityTypeTransformationService.TransformPropertyName)})");
 
             var defaultOnDeleteAction = foreignKey.IsRequired
@@ -820,10 +820,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             var joinEntityType = skipNavigation.JoinEntityType;
             using (sb.Indent())
             {
-                sb.AppendLine($"{EntityLambdaIdentifier}.{nameof(EntityTypeBuilder.HasMany)}(d => d.{EntityTypeTransformationService.TransformTypeEntityName(skipNavigation.Name)})");
+                sb.AppendLine($"{EntityLambdaIdentifier}.{nameof(EntityTypeBuilder.HasMany)}(d => d.{EntityTypeTransformationService.TransformTypeEntityName(skipNavigation.JoinEntityType, skipNavigation.Name)})");
                 using (sb.Indent())
                 {
-                    sb.AppendLine($".{nameof(CollectionNavigationBuilder.WithMany)}(p => p.{EntityTypeTransformationService.TransformTypeEntityName(inverse.Name)})");
+                    sb.AppendLine($".{nameof(CollectionNavigationBuilder.WithMany)}(p => p.{EntityTypeTransformationService.TransformTypeEntityName(inverse.DeclaringEntityType, inverse.Name)})");
                     sb.AppendLine(
                         $".{nameof(CollectionCollectionBuilder.UsingEntity)}<{CSharpHelper.Reference(Model.DefaultPropertyBagType)}>(");
                     using (sb.Indent())
@@ -831,8 +831,8 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         sb.AppendLine($"{CSharpHelper.Literal(joinEntityType.Name)},");
                         var lines = new List<string>();
 
-                        var navEntityTypeName = GetEntityTypeName(inverse.ForeignKey.PrincipalEntityType, EntityTypeTransformationService.TransformTypeEntityName(inverse.ForeignKey.PrincipalEntityType.Name));
-                        var skipNavEntityTypeName = GetEntityTypeName(skipNavigation.ForeignKey.PrincipalEntityType, EntityTypeTransformationService.TransformTypeEntityName(skipNavigation.ForeignKey.PrincipalEntityType.Name));
+                        var navEntityTypeName = GetEntityTypeName(inverse.ForeignKey.PrincipalEntityType, EntityTypeTransformationService.TransformTypeEntityName(inverse.ForeignKey.PrincipalEntityType, inverse.ForeignKey.PrincipalEntityType.Name));
+                        var skipNavEntityTypeName = GetEntityTypeName(skipNavigation.ForeignKey.PrincipalEntityType, EntityTypeTransformationService.TransformTypeEntityName(skipNavigation.ForeignKey.PrincipalEntityType, skipNavigation.ForeignKey.PrincipalEntityType.Name));
                         GenerateForeignKeyConfigurationLines(inverse.ForeignKey, navEntityTypeName, "l");
                         GenerateForeignKeyConfigurationLines(skipNavigation.ForeignKey, skipNavEntityTypeName, "r");
                         sb.AppendLine("j =>");

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpEntityTypeGenerator.cs
@@ -189,7 +189,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                 GenerateEntityTypeDataAnnotations(entityType);
             }
 
-            var transformedEntityName = EntityTypeTransformationService.TransformTypeEntityName(entityType.Name);
+            var transformedEntityName = EntityTypeTransformationService.TransformTypeEntityName(entityType, entityType.Name);
 
             if (_options?.Value?.GenerateComments == true)
                 TemplateData.Add("comment", GenerateComment(entityType.GetComment(), 1));
@@ -220,10 +220,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                 foreach (var navigation in collectionNavigations)
                 {
+                    var navPropertyType = EntityTypeTransformationService.TransformTypeEntityName(navigation.TargetEntityType, navigation.TargetEntityType.Name);
                     lines.Add(new Dictionary<string, object>
                     {
                         { "property-name", navigation.Name },
-                        { "property-type", navigation.TargetEntityType.Name }
+                        { "property-type", navPropertyType }
                     });
                 }
 
@@ -335,7 +336,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     var propertyIsNullable = !navigation.IsCollection &&
                         UseNullableReferenceTypes &&
                         !navigation.ForeignKey.IsRequired;
-                    var navPropertyType = navigation.TargetEntityType.Name;
+                    var navPropertyType = EntityTypeTransformationService.TransformTypeEntityName(navigation.TargetEntityType, navigation.TargetEntityType.Name);
                     navProperties.Add(new Dictionary<string, object>
                     {
                         { "nav-property-collection", navigation.IsCollection },
@@ -378,7 +379,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     var propertyIsNullable = !navigation.IsCollection &&
                         UseNullableReferenceTypes &&
                         !navigation.ForeignKey.IsRequired;
-                    var navPropertyType = navigation.TargetEntityType.Name;
+                    var navPropertyType = EntityTypeTransformationService.TransformTypeEntityName(navigation.TargetEntityType, navigation.TargetEntityType.Name);
                     if (propertyIsNullable &&
                         !navPropertyType.EndsWith("?")) {
                         navPropertyType += "?";
@@ -689,7 +690,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                                 m => m.Name == inverseNavigation.DeclaringEntityType.Name ||
                                     EntityTypeTransformationService.TransformNavPropertyName(entityType, m.Name, navigation.TargetEntityType.Name)
                                         == EntityTypeTransformationService.TransformNavPropertyName(entityType, inverseNavigation.DeclaringEntityType.Name, navigation.TargetEntityType.Name))
-                            ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringType.Name)}.{propertyName})"
+                            ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringEntityType, inverseNavigation.DeclaringType.Name)}.{propertyName})"
                             : CSharpHelper.Literal(propertyName));
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>
@@ -766,7 +767,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                                 m => m.Name == inverseNavigation.DeclaringEntityType.Name ||
                                     EntityTypeTransformationService.TransformNavPropertyName(entityType, m.Name, navigation.TargetEntityType.Name)
                                         == EntityTypeTransformationService.TransformNavPropertyName(entityType, inverseNavigation.DeclaringEntityType.Name, navigation.TargetEntityType.Name))
-                            ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringType.Name)}.{propertyName})"
+                            ? $"nameof({EntityTypeTransformationService.TransformTypeEntityName(inverseNavigation.DeclaringEntityType, inverseNavigation.DeclaringType.Name)}.{propertyName})"
                             : CSharpHelper.Literal(propertyName));
 
                     NavPropertyAnnotations.Add(new Dictionary<string, object>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
@@ -169,7 +169,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         options.UseDataAnnotations,
                         options.UseNullableReferenceTypes);
 
-                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.Name);
+                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType, entityType.Name);
                     var schema = !string.IsNullOrEmpty(entityType.GetTableName())
                         ? entityType.GetSchema()
                         : entityType.GetViewSchema();

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService2.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationService2.cs
@@ -52,5 +52,27 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             PropertyTransformer2 = propertyTransformer;
             NavPropertyTransformer2 = navPropertyTransformer;
         }
+
+        /// <summary>
+        /// HbsEntityTypeTransformationService constructor.
+        /// </summary>
+        /// <param name="entityTypeNameTransformer">Entity type name transformer.</param>
+        /// <param name="entityFileNameTransformer">Entity file name transformer.</param>
+        /// <param name="constructorTransformer">Constructor transformer.</param>
+        /// <param name="propertyTransformer">Property name transformer.</param>
+        /// <param name="navPropertyTransformer">Navigation property name transformer.</param>
+        public HbsEntityTypeTransformationService2(
+            Func<IEntityType, string, string> entityTypeNameTransformer = null,
+            Func<IEntityType, string, string> entityFileNameTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null)
+        {
+            EntityTypeNameTransformer2 = entityTypeNameTransformer;
+            EntityFileNameTransformer2 = entityFileNameTransformer;
+            ConstructorTransformer2 = constructorTransformer;
+            PropertyTransformer2 = propertyTransformer;
+            NavPropertyTransformer2 = navPropertyTransformer;
+        }
     }
 }

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationServiceBase.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsEntityTypeTransformationServiceBase.cs
@@ -34,6 +34,16 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         protected Func<EntityPropertyInfo, EntityPropertyInfo> NavPropertyTransformer { get; set; }
 
         /// <summary>
+        /// Entity name transformer.
+        /// </summary>
+        protected Func<IEntityType, string, string> EntityTypeNameTransformer2 { get; set; }
+
+        /// <summary>
+        /// Entity file name transformer.
+        /// </summary>
+        protected Func<IEntityType, string, string> EntityFileNameTransformer2 { get; set; }
+
+        /// <summary>
         /// Constructor transformer.
         /// </summary>
         protected Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> ConstructorTransformer2 { get; set; }
@@ -70,12 +80,34 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
             EntityTypeNameTransformer?.Invoke(entityName) ?? entityName;
 
         /// <summary>
+        /// Transform entity type name.
+        /// </summary>
+        /// <param name="entityType">Entity type.</param>
+        /// <param name="entityName">Entity type name.</param>
+        /// <returns>Transformed entity type name.</returns>
+        public string TransformTypeEntityName(IEntityType entityType, string entityName) =>
+            EntityTypeNameTransformer2?.Invoke(entityType, entityName)
+            ?? EntityTypeNameTransformer?.Invoke(entityName)
+            ?? entityName;
+
+        /// <summary>
         /// Transform entity file name.
         /// </summary>
         /// <param name="entityFileName">Entity file name.</param>
         /// <returns>Transformed entity file name.</returns>
         public string TransformEntityFileName(string entityFileName) =>
             EntityFileNameTransformer?.Invoke(entityFileName) ?? entityFileName;
+
+        /// <summary>
+        /// Transform entity file name.
+        /// </summary>
+        /// <param name="entityType">Entity type.</param>
+        /// <param name="entityFileName">Entity file name.</param>
+        /// <returns>Transformed entity file name.</returns>
+        public string TransformEntityFileName(IEntityType entityType, string entityFileName) => 
+            EntityFileNameTransformer2?.Invoke(entityType, entityFileName) 
+            ?? EntityFileNameTransformer?.Invoke(entityFileName) 
+            ?? entityFileName;
 
         /// <summary>
         /// Transform single property name.

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptEntityTypeGenerator.cs
@@ -131,7 +131,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         {
             Check.NotNull(entityType, nameof(entityType));
 
-            var transformedEntityName = EntityTypeTransformationService.TransformTypeEntityName(entityType.Name);
+            var transformedEntityName = EntityTypeTransformationService.TransformTypeEntityName(entityType, entityType.Name);
 
             TemplateData.Add("comment", entityType.GetComment());
             TemplateData.Add("class", transformedEntityName);
@@ -158,10 +158,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                 foreach (var navigation in collectionNavigations)
                 {
+                    var navPropertyType = EntityTypeTransformationService.TransformTypeEntityName(navigation.TargetEntityType, navigation.TargetEntityType.Name);
                     lines.Add(new Dictionary<string, object>
                     {
                         { "property-name", navigation.Name },
-                        { "property-type", navigation.TargetEntityType.Name },
+                        { "property-type", navPropertyType },
                     });
                 }
 
@@ -219,10 +220,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                 foreach (var navigation in sortedNavigations)
                 {
+                    var navPropertyType = EntityTypeTransformationService.TransformTypeEntityName(navigation.TargetEntityType, navigation.TargetEntityType.Name);
                     navProperties.Add(new Dictionary<string, object>
                     {
                         { "nav-property-collection", navigation.IsCollection },
-                        { "nav-property-type", navigation.TargetEntityType.Name },
+                        { "nav-property-type", navPropertyType },
                         { "nav-property-name", TypeScriptHelper.ToCamelCase(navigation.Name) },
                         { "nav-property-annotations", new List<Dictionary<string, object>>() },
                         { "nav-property-isnullable", false },
@@ -254,10 +256,11 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
 
                 foreach (var navigation in sortedNavigations)
                 {
+                    var navPropertyType = EntityTypeTransformationService.TransformTypeEntityName(navigation.TargetEntityType, navigation.TargetEntityType.Name);
                     navProperties.Add(new Dictionary<string, object>
                     {
                         { "nav-property-collection", navigation.IsCollection },
-                        { "nav-property-type", navigation.TargetEntityType.Name },
+                        { "nav-property-type", navPropertyType },
                         { "nav-property-name", TypeScriptHelper.ToCamelCase(navigation.Name) },
                         { "nav-property-annotations", new List<Dictionary<string, object>>() },
                         { "nav-property-isnullable", false },

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptModelGenerator.cs
@@ -157,7 +157,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                         options.UseDataAnnotations,
                         options.UseNullableReferenceTypes);
 
-                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType.Name);
+                    var transformedFileName = EntityTypeTransformationService.TransformEntityFileName(entityType, entityType.Name);
                     var entityTypeFileName = transformedFileName + FileExtension;
                     if (_options?.Value?.EnableSchemaFolders == true) {
                         entityTypeFileName = entityType.GetSchema() + @"\" + entityTypeFileName;

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/IEntityTypeTransformationService.cs
@@ -16,11 +16,33 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
         string TransformTypeEntityName(string entityName);
 
         /// <summary>
+        /// Transform entity type name.
+        /// </summary>
+        /// <param name="entityType">Entity type.</param>
+        /// <param name="entityName">Entity type name.</param>
+        /// <returns>Transformed entity type name.</returns>
+        string TransformTypeEntityName(IEntityType entityType, string entityName)
+        {
+            return TransformTypeEntityName(entityName);
+        }
+
+        /// <summary>
         /// Transform entity file name.
         /// </summary>
         /// <param name="entityFileName">Entity file name.</param>
         /// <returns>Transformed entity file name.</returns>
         string TransformEntityFileName(string entityFileName);
+
+        /// <summary>
+        /// Transform entity file name.
+        /// </summary>
+        /// <param name="entityType">Entity type.</param>
+        /// <param name="entityFileName">Entity file name.</param>
+        /// <returns>Transformed entity file name.</returns>
+        string TransformEntityFileName(IEntityType entityType, string entityFileName)
+        {
+            return TransformEntityFileName(entityFileName);
+        }
 
         /// <summary>
         /// Transform single property name.

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using EntityFrameworkCore.Scaffolding.Handlebars.Helpers;
 using EntityFrameworkCore.Scaffolding.Handlebars.Internal;
 using HandlebarsDotNet;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.Extensions.DependencyInjection;
 using HandlebarsLib = HandlebarsDotNet.Handlebars;
@@ -235,6 +236,41 @@ namespace Microsoft.EntityFrameworkCore.Design
         public static IServiceCollection AddHandlebarsTransformers2(this IServiceCollection services,
             Func<string, string> entityTypeNameTransformer = null,
             Func<string, string> entityFileNameTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
+            Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null,
+            Func<string, string> contextFileNameTransformer = null)
+        {
+            services.AddSingleton<IEntityTypeTransformationService>(provider =>
+                new HbsEntityTypeTransformationService2(
+                    entityTypeNameTransformer,
+                    entityFileNameTransformer,
+                    constructorTransformer,
+                    propertyTransformer,
+                    navPropertyTransformer));
+            services.AddSingleton<IContextTransformationService>(provider =>
+                new HbsContextTransformationService(contextFileNameTransformer));
+            return services;
+        }
+
+        /// <summary>
+        /// Register Handlebars transformers.
+        ///     <para>
+        ///         Note: You must first call AddHandlebarsScaffolding before calling AddHandlebarsTransformers.
+        ///         This overload surfaces IEntityType in the transformers.
+        ///     </para>
+        /// </summary>
+        /// <param name="services"> The <see cref="IServiceCollection" /> to add services to. </param>
+        /// <param name="entityTypeNameTransformer">Entity name transformer.</param>
+        /// <param name="entityFileNameTransformer">Entity file name transformer.</param>
+        /// <param name="constructorTransformer"></param>
+        /// <param name="propertyTransformer">Property name transformer.</param>
+        /// <param name="navPropertyTransformer">Navigation property name transformer.</param>
+        /// <param name="contextFileNameTransformer">Context file name transformer.</param>
+        /// <returns>The same service collection so that multiple calls can be chained.</returns>
+        public static IServiceCollection AddHandlebarsEntityTypeTransformers(this IServiceCollection services,
+            Func<IEntityType, string, string> entityTypeNameTransformer = null,
+            Func<IEntityType, string, string> entityFileNameTransformer = null,
             Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> constructorTransformer = null,
             Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> propertyTransformer = null,
             Func<IEntityType, EntityPropertyInfo, EntityPropertyInfo> navPropertyTransformer = null,

--- a/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
+++ b/test/Scaffolding.Handlebars.Tests/ExpectedEntities.cs
@@ -1,4 +1,6 @@
-﻿namespace Scaffolding.Handlebars.Tests
+﻿using Scaffolding.Handlebars.Tests.Helpers;
+
+namespace Scaffolding.Handlebars.Tests
 {
     public partial class HbsCSharpScaffoldingGeneratorTests
     {
@@ -55,53 +57,59 @@ namespace FakeNamespace
 
         private static class ExpectedEntitiesWithTransformMappings
         {
-            public const string CategoryClass =
+            public const string CategoryClassConst =
 @"using System;
 using System.Collections.Generic;
 
 namespace FakeNamespace
-{
+{{
     /// <summary>
     /// A category of products
     /// </summary>
-    public partial class CategoryRenamed
-    {
-        public CategoryRenamed()
-        {
-            Products = new HashSet<ProductRenamed>();
-        }
+    public partial class {0}
+    {{
+        public {0}()
+        {{
+            Products = new HashSet<{1}>();
+        }}
 
-        public int CategoryIdRenamed { get; set; }
+        public int CategoryIdRenamed {{ get; set; }}
 
         /// <summary>
         /// The name of a category
         /// </summary>
-        public string CategoryNameRenamed { get; set; }
+        public string CategoryNameRenamed {{ get; set; }}
 
-        public virtual ICollection<ProductRenamed> Products { get; set; }
-    }
-}
+        public virtual ICollection<{1}> Products {{ get; set; }}
+    }}
+}}
 ";
 
-            public const string ProductClass =
+            public const string ProductClassConst =
 @"using System;
 using System.Collections.Generic;
 
 namespace FakeNamespace
-{
-    public partial class ProductRenamed
-    {
-        public int ProductIdRenamed { get; set; }
-        public string ProductName { get; set; }
-        public decimal? UnitPriceRenamed { get; set; }
-        public bool Discontinued { get; set; }
-        public byte[] RowVersion { get; set; }
-        public int? CategoryIdRenamed { get; set; }
+{{
+    public partial class {0}
+    {{
+        public int ProductIdRenamed {{ get; set; }}
+        public string ProductName {{ get; set; }}
+        public decimal? UnitPriceRenamed {{ get; set; }}
+        public bool Discontinued {{ get; set; }}
+        public byte[] RowVersion {{ get; set; }}
+        public int? CategoryIdRenamed {{ get; set; }}
 
-        public virtual CategoryRenamed Category { get; set; }
-    }
-}
+        public virtual {1} Category {{ get; set; }}
+    }}
+}}
 ";
+
+            public static readonly string CategoryClass = string.Format(CategoryClassConst, Constants.Names.Transformed.Category, Constants.Names.Transformed.Product);
+            public static readonly string CategoryClassTransformed2 = string.Format(CategoryClassConst, Constants.Names.Transformed2.Category, Constants.Names.Transformed2.Product);
+
+            public static readonly string ProductClass = string.Format(ProductClassConst, Constants.Names.Transformed.Product, Constants.Names.Transformed.Category);
+            public static readonly string ProductClassTransformed2 = string.Format(ProductClassConst, Constants.Names.Transformed2.Product, Constants.Names.Transformed2.Category);
         }
 
         private static class ExpectedEntitiesNoEncoding
@@ -230,7 +238,7 @@ namespace FakeNamespace
 
         private static class ExpectedEntitiesWithAnnotationsAndTransformMappings
         {
-            public const string CategoryClass =
+            public const string CategoryClassConst =
                 @"using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -238,21 +246,21 @@ using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace FakeNamespace
-{
+{{
     /// <summary>
     /// A category of products
     /// </summary>
     [Table(""Category"")]
-    public partial class CategoryRenamed
-    {
-        public CategoryRenamed()
-        {
-            Products = new HashSet<ProductRenamed>();
-        }
+    public partial class {0}
+    {{
+        public {0}()
+        {{
+            Products = new HashSet<{1}>();
+        }}
 
         [Key]
         [Column(""CategoryId"")]
-        public int CategoryIdRenamed { get; set; }
+        public int CategoryIdRenamed {{ get; set; }}
 
         /// <summary>
         /// The name of a category
@@ -260,15 +268,15 @@ namespace FakeNamespace
         [Required]
         [Column(""CategoryName"")]
         [StringLength(15)]
-        public string CategoryNameRenamed { get; set; }
+        public string CategoryNameRenamed {{ get; set; }}
 
-        [InverseProperty(nameof(ProductRenamed.Category))]
-        public virtual ICollection<ProductRenamed> Products { get; set; }
-    }
-}
+        [InverseProperty(nameof({1}.Category))]
+        public virtual ICollection<{1}> Products {{ get; set; }}
+    }}
+}}
 ";
 
-            public const string ProductClass =
+            public const string ProductClassConst =
                 @"using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -276,30 +284,37 @@ using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace FakeNamespace
-{
+{{
     [Table(""Product"")]
     [Index(nameof(CategoryId), Name = ""IX_Product_CategoryId"")]
-    public partial class ProductRenamed
-    {
+    public partial class {0}
+    {{
         [Key]
         [Column(""ProductId"")]
-        public int ProductIdRenamed { get; set; }
+        public int ProductIdRenamed {{ get; set; }}
         [Required]
         [StringLength(40)]
-        public string ProductName { get; set; }
+        public string ProductName {{ get; set; }}
         [Column(""UnitPrice"", TypeName = ""money"")]
-        public decimal? UnitPriceRenamed { get; set; }
-        public bool Discontinued { get; set; }
-        public byte[] RowVersion { get; set; }
+        public decimal? UnitPriceRenamed {{ get; set; }}
+        public bool Discontinued {{ get; set; }}
+        public byte[] RowVersion {{ get; set; }}
         [Column(""CategoryId"")]
-        public int? CategoryIdRenamed { get; set; }
+        public int? CategoryIdRenamed {{ get; set; }}
 
         [ForeignKey(nameof(CategoryIdRenamed))]
         [InverseProperty(""Products"")]
-        public virtual CategoryRenamed Category { get; set; }
-    }
-}
+        public virtual {1} Category {{ get; set; }}
+    }}
+}}
 ";
+
+            public static readonly string CategoryClass = string.Format(CategoryClassConst, Constants.Names.Transformed.Category, Constants.Names.Transformed.Product);
+            public static readonly string CategoryClassTransformed2 = string.Format(CategoryClassConst, Constants.Names.Transformed2.Category, Constants.Names.Transformed2.Product);
+
+            public static readonly string ProductClass = string.Format(ProductClassConst, Constants.Names.Transformed.Product, Constants.Names.Transformed.Category);
+            public static readonly string ProductClassTransformed2 = string.Format(ProductClassConst, Constants.Names.Transformed2.Product, Constants.Names.Transformed2.Category);
+
         }
 
         private static class ExpectedEntitiesWithAnnotationsNoEncoding

--- a/test/Scaffolding.Handlebars.Tests/Helpers/Constants.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/Constants.cs
@@ -46,14 +46,38 @@
             }
         }
 
+        public static class Names
+        {
+            public const string Category = "Category";
+            public const string Customer = "Customer";
+            public const string Product = "Product";
+
+            public static class Transformed
+            {
+                public const string Category = Names.Category + "Renamed";
+                public const string Customer = Names.Customer + "Renamed";
+                public const string Product = Names.Product + "Renamed";
+            }
+
+            public static class Transformed2
+            {
+                public const string Category = "dbo_" + Transformed.Category;
+                public const string Customer = "dbo_" + Transformed.Customer;
+                public const string Product = "dbo_" + Transformed.Product;
+            }
+        }
+
         public static class Files
         {
             public static class CSharpFiles
             {
                 public const string DbContextFile = Parameters.ContextName + ".cs";
                 public const string CategoryFile = "Category.cs";
+                public const string CategoryFileTransformed2 = "dbo_" + CategoryFile;
                 public const string CustomerFile = "Customer.cs";
+                public const string CustomerFileTransformed2 = "dbo_" + CustomerFile;
                 public const string ProductFile = "Product.cs";
+                public const string ProductFileTransformed2 = "dbo_" + ProductFile;
             }
             public static class TypeScriptFiles
             {

--- a/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
+++ b/test/Scaffolding.Handlebars.Tests/Helpers/HandlebarsTransformers.cs
@@ -1,5 +1,8 @@
+using System;
 using EntityFrameworkCore.Scaffolding.Handlebars;
 using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Scaffolding.Handlebars.Tests.Helpers
 {
@@ -11,6 +14,14 @@ namespace Scaffolding.Handlebars.Tests.Helpers
             { "Customer","CustomerRenamed" },
             { "Category", "CategoryRenamed" }
         };
+
+        static readonly Dictionary<string, Func<IEntityType, string, string>> _entityTypeNameMappings2 = new()
+        {
+            { "Product", (entityType, _) => entityType.GetSchema() + "_ProductRenamed" },
+            { "Customer", (entityType, _) => entityType.GetSchema() + "_CustomerRenamed" },
+            { "Category", (entityType, _) => entityType.GetSchema() + "_CategoryRenamed" }
+        };
+
         static readonly Dictionary<string, string> _entityPropertyNameMappings = new()
         {
             { "ProductId", "ProductIdRenamed" },
@@ -18,14 +29,24 @@ namespace Scaffolding.Handlebars.Tests.Helpers
             { "CategoryId", "CategoryIdRenamed" },
             { "CategoryName","CategoryNameRenamed" }
         };
+
         public static string MapEntityName(string entityName) =>
             _entityTypeNameMappings.TryGetValue(entityName, out var nameOverride) ? nameOverride : entityName;
+
+        public static string MapEntityName2(IEntityType entityType, string entityName) =>
+            _entityTypeNameMappings2.TryGetValue(entityName, out var nameOverride) ? nameOverride(entityType, entityName) : entityName;
 
         public static EntityPropertyInfo MapNavPropertyInfo(EntityPropertyInfo e) =>
             new(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
 
+        public static EntityPropertyInfo MapNavPropertyInfo2(IEntityType entityType, EntityPropertyInfo e) =>
+            new(MapEntityName2(entityType, e.PropertyType), MapPropertyName(e.PropertyName));
+
         public static EntityPropertyInfo MapPropertyInfo(EntityPropertyInfo e) =>
             new(MapPropertyTypeName(e.PropertyType), MapPropertyName(e.PropertyName));
+
+        public static EntityPropertyInfo MapPropertyInfo2(IEntityType entityType, EntityPropertyInfo e) =>
+            new(MapEntityName2(entityType, e.PropertyType), MapPropertyName(e.PropertyName));
 
         private static string MapPropertyTypeName(string propertyTypeName) =>
             _entityTypeNameMappings.TryGetValue(propertyTypeName, out var propertyTypeNameOverride) ? propertyTypeNameOverride : propertyTypeName;


### PR DESCRIPTION
Updated version of #233 to include latest .Net 8 changes. Adds functionality to use IEntityType in the entity type name and entity file name transformers. No breaking changes I'm aware of, I forgot default interface methods existed which resolved my biggest roadblock with changing the interface.

Closes #232.