### PR TITLE
Upgrade to .NET 10 and EF Core 10.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Before creating a pull request, please refer to the [Contributing Guidelines](ht
 
 ## Prerequisites
 
-- [Visual Studio 2022](https://www.visualstudio.com/downloads/) or greater, [JetBrains Rider](https://www.jetbrains.com/rider) 2024.3 or greater.
-- [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet) or greater.
-- [EF Core CLI 9.0](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) or greater.
+- [Visual Studio 2026](https://www.visualstudio.com/downloads/) or greater, [JetBrains Rider](https://www.jetbrains.com/rider) 2025.3 or greater.
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet) or greater.
+- [EF Core CLI 10.0](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) or greater.
   - Install global `dotnet-ef` tool.
     ```
     dotnet tool install --global dotnet-ef
@@ -54,10 +54,10 @@ docker run -e "ACCEPT_EULA=1" -e "MSSQL_SA_PASSWORD=MyPass@word" -e "MSSQL_PID=D
 
 ## Upgrading
 
-1. Upgrade `TargetFramework` in **.csproj** file to `net8.0` or `net9.0`.
+1. Upgrade `TargetFramework` in **.csproj** file to `net10.0`.
    - Optional: Set `ImplicitUsings` to `enable`.
    - Optional: Set `Nullable` to `enable`.
-2. Update the following NuGet packages to `9.0.0` or later:
+2. Update the following NuGet packages to `10.0.0` or later:
    - Microsoft.EntityFrameworkCore.Design
    - Microsoft.EntityFrameworkCore.SqlServer
    - EntityFrameworkCore.Scaffolding.Handlebars
@@ -69,7 +69,7 @@ docker run -e "ACCEPT_EULA=1" -e "MSSQL_SA_PASSWORD=MyPass@word" -e "MSSQL_PID=D
 
 ## Usage
 
-1. Create a new **.NET 8** or **.NET 9** class library.
+1. Create a new **.NET 10** class library.
 
 2. Add EF Core SQL Server and Tools NuGet packages.
     - `Microsoft.EntityFrameworkCore.SqlServer`
@@ -126,7 +126,7 @@ Take advantage of C# nullable reference types by enabling them in your .csproj f
 
 ```xml
 <PropertyGroup>
-  <TargetFramework>net6.0</TargetFramework>
+  <TargetFramework>net10.0</TargetFramework>
   <Nullable>enable</Nullable>
 </PropertyGroup>
 ```

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.100",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/sample/ScaffoldingSample.Api/ScaffoldingSample.Api.csproj
+++ b/sample/ScaffoldingSample.Api/ScaffoldingSample.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>false</InvariantGlobalization>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/sample/ScaffoldingSample.Embedded/ScaffoldingSample.Embedded.csproj
+++ b/sample/ScaffoldingSample.Embedded/ScaffoldingSample.Embedded.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/ScaffoldingSample.TypeScript/ScaffoldingSample.TypeScript.csproj
+++ b/sample/ScaffoldingSample.TypeScript/ScaffoldingSample.TypeScript.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/ScaffoldingSample/ScaffoldingSample.csproj
+++ b/sample/ScaffoldingSample/ScaffoldingSample.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>9.0.0</Version>
+    <Version>10.0.0</Version>
     <Authors>Tony Sneed</Authors>
     <Company>Tony Sneed</Company>
     <Title>Entity Framework Core Scaffolding with Handlebars</Title>
@@ -12,22 +12,22 @@
     <PackageProjectUrl>https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>scaffolding reverse-engineer entity-framework-core handlebars</PackageTags>
-    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v9.0.0</PackageReleaseNotes>
+    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v10.0.0</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <IncludeSource>true</IncludeSource>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
-    <AssemblyVersion>9.0.0.0</AssemblyVersion>
-    <FileVersion>9.0.0.0</FileVersion>
+    <AssemblyVersion>10.0.0.0</AssemblyVersion>
+    <FileVersion>10.0.0.0</FileVersion>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Handlebars.Net" Version="2.1.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
+    <PackageReference Include="Handlebars.Net" Version="2.1.6" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
 	<ItemGroup>
@@ -37,10 +37,11 @@
 
 	<ItemGroup>
     <Content Include="EntityFrameworkCore.Scaffolding.Handlebars.targets" PackagePath="build/EntityFrameworkCore.Scaffolding.Handlebars.targets" />
-    <Content Include="CodeTemplates/**/*.*" Pack="true" PackagePath="lib/net8.0/CodeTemplates">
+    <Content Include="CodeTemplates/**/*.*" Pack="true" PackagePath="lib/net10.0/CodeTemplates">
       <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
   </ItemGroup>
+
 
   <ItemGroup>
 	<None Update="CodeTemplates\CSharpDbContext\DbContext.hbs">

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/Internal/Check.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/Internal/Check.cs
@@ -34,7 +34,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Internal
             {
                 NotEmpty(parameterName, nameof(parameterName));
 
-                throw new ArgumentException(AbstractionsStrings.CollectionArgumentIsEmpty(parameterName));
+                throw new ArgumentException($"The collection argument '{parameterName}' must contain at least one element.");
             }
 
             return value;
@@ -50,7 +50,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Internal
             }
             else if (value.Trim().Length == 0)
             {
-                e = new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
+                e = new ArgumentException($"The string argument '{parameterName}' cannot be empty.");
             }
 
             if (e != null)
@@ -70,7 +70,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Internal
             {
                 NotEmpty(parameterName, nameof(parameterName));
 
-                throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
+                throw new ArgumentException($"The string argument '{parameterName}' cannot be empty.");
             }
 
             return value;

--- a/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
+++ b/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>7cd5132a-1f06-4001-b62c-51cdcbe38dbf</UserSecretsId>
@@ -12,14 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

This PR upgrades the library and all sample/test projects to .NET 10 and pins EF Core to `10.0.0`.

- Bumps all `TargetFramework` values from `net8.0` → `net10.0` (TemplatesAssembly remains on `netstandard2.1`)
- Pins `Microsoft.EntityFrameworkCore.Design` and `Microsoft.EntityFrameworkCore.Relational/SqlServer` to `10.0.0`
- Updates `Handlebars.Net` to `2.1.6` and `JetBrains.Annotations` to `2025.2.4`
- Updates `Microsoft.AspNetCore.OpenApi` and `Microsoft.VisualStudio.Web.CodeGeneration.Design` to `10.0.0`
- Bumps package version to `10.0.0` (assembly and file versions updated accordingly)
- Updates `CodeTemplates` NuGet package path from `lib/net8.0` → `lib/net10.0`
- Updates README prerequisites, upgrade steps, and code samples to reference .NET 10

Resolves https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/issues/249 https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/issues/250

## Breaking Change Fix

`AbstractionsStrings.CollectionArgumentIsEmpty` and `AbstractionsStrings.ArgumentIsEmpty` changed from callable methods to properties in EF Core 10. The calls in `Internal/Check.cs` have been replaced with equivalent inline interpolated string messages.

## EF Core Scaffolding Template Compatibility

The EF Core scaffolding generators (`CSharpDbContextGenerator` and `CSharpEntityTypeGenerator`) are unchanged between v9 and v10 — confirmed by diffing the source files on GitHub. All Handlebars templates (`.hbs` files) and the template data model are fully compatible with EF Core 10 with no modifications required.

## Test Plan

- [x] `dotnet build` succeeds with 0 errors (3 pre-existing connection string warnings in sample projects)
- [x] `dotnet test` — succeeds