### PR TITLE
Upgrade to .NET 10 / EF Core 10.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Before creating a pull request, please refer to the [Contributing Guidelines](ht
 ## Prerequisites
 
 - [Visual Studio 2022](https://www.visualstudio.com/downloads/) or greater, [JetBrains Rider](https://www.jetbrains.com/rider) 2024.3 or greater.
-- [.NET 9.0 SDK](https://dotnet.microsoft.com/download/dotnet) or greater.
-- [EF Core CLI 9.0](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) or greater.
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet) or greater.
+- [EF Core CLI 10.0](https://docs.microsoft.com/en-us/ef/core/cli/dotnet) or greater.
   - Install global `dotnet-ef` tool.
     ```
     dotnet tool install --global dotnet-ef
@@ -54,10 +54,10 @@ docker run -e "ACCEPT_EULA=1" -e "MSSQL_SA_PASSWORD=MyPass@word" -e "MSSQL_PID=D
 
 ## Upgrading
 
-1. Upgrade `TargetFramework` in **.csproj** file to `net8.0` or `net9.0`.
+1. Upgrade `TargetFramework` in **.csproj** file to `net10.0`.
    - Optional: Set `ImplicitUsings` to `enable`.
    - Optional: Set `Nullable` to `enable`.
-2. Update the following NuGet packages to `9.0.0` or later:
+2. Update the following NuGet packages to `10.0.0` or later:
    - Microsoft.EntityFrameworkCore.Design
    - Microsoft.EntityFrameworkCore.SqlServer
    - EntityFrameworkCore.Scaffolding.Handlebars
@@ -69,7 +69,7 @@ docker run -e "ACCEPT_EULA=1" -e "MSSQL_SA_PASSWORD=MyPass@word" -e "MSSQL_PID=D
 
 ## Usage
 
-1. Create a new **.NET 8** or **.NET 9** class library.
+1. Create a new **.NET 10** class library.
 
 2. Add EF Core SQL Server and Tools NuGet packages.
     - `Microsoft.EntityFrameworkCore.SqlServer`

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/sample/ScaffoldingSample.Api/ScaffoldingSample.Api.csproj
+++ b/sample/ScaffoldingSample.Api/ScaffoldingSample.Api.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>false</InvariantGlobalization>
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sample/ScaffoldingSample.Embedded/ScaffoldingSample.Embedded.csproj
+++ b/sample/ScaffoldingSample.Embedded/ScaffoldingSample.Embedded.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/ScaffoldingSample.TypeScript/ScaffoldingSample.TypeScript.csproj
+++ b/sample/ScaffoldingSample.TypeScript/ScaffoldingSample.TypeScript.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/ScaffoldingSample/ScaffoldingSample.csproj
+++ b/sample/ScaffoldingSample/ScaffoldingSample.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/TemplatesAssembly/TemplatesAssembly.csproj
+++ b/sample/TemplatesAssembly/TemplatesAssembly.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/EntityFrameworkCore.Scaffolding.Handlebars.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>9.0.0</Version>
+    <Version>10.0.0</Version>
     <Authors>Tony Sneed</Authors>
     <Company>Tony Sneed</Company>
     <Title>Entity Framework Core Scaffolding with Handlebars</Title>
@@ -12,22 +12,22 @@
     <PackageProjectUrl>https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageTags>scaffolding reverse-engineer entity-framework-core handlebars</PackageTags>
-    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v9.0.0</PackageReleaseNotes>
+    <PackageReleaseNotes>See: https://github.com/TrackableEntities/EntityFrameworkCore.Scaffolding.Handlebars/releases/tag/v10.0.0</PackageReleaseNotes>
     <LangVersion>latest</LangVersion>
     <IncludeSource>true</IncludeSource>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
-    <AssemblyVersion>9.0.0.0</AssemblyVersion>
-    <FileVersion>9.0.0.0</FileVersion>
+    <AssemblyVersion>10.0.0.0</AssemblyVersion>
+    <FileVersion>10.0.0.0</FileVersion>
 	<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Handlebars.Net" Version="2.1.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
+    <PackageReference Include="Handlebars.Net" Version="2.1.6" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
   </ItemGroup>
 
 	<ItemGroup>
@@ -37,7 +37,7 @@
 
 	<ItemGroup>
     <Content Include="EntityFrameworkCore.Scaffolding.Handlebars.targets" PackagePath="build/EntityFrameworkCore.Scaffolding.Handlebars.targets" />
-    <Content Include="CodeTemplates/**/*.*" Pack="true" PackagePath="lib/net8.0/CodeTemplates">
+    <Content Include="CodeTemplates/**/*.*" Pack="true" PackagePath="lib/net10.0/CodeTemplates">
       <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
   </ItemGroup>

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsCSharpModelGenerator.cs
@@ -146,9 +146,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     options.SuppressOnConfiguring);
 
                 var dbContextFileName = ContextTransformationService.TransformContextFileName(options.ContextName) + FileExtension;
-                resultingFiles.ContextFile = new ScaffoldedFile(options.ContextDir != null
+                var dbContextPath = options.ContextDir != null
                     ? Path.Combine(options.ContextDir, dbContextFileName)
-                    : dbContextFileName, generatedCode);
+                    : dbContextFileName;
+                resultingFiles.ContextFile = new ScaffoldedFile(dbContextPath, generatedCode);
             }
 
             if (!(CSharpEntityTypeGenerator is NullCSharpEntityTypeGenerator))

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptModelGenerator.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/HbsTypeScriptModelGenerator.cs
@@ -138,9 +138,10 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars
                     options.SuppressOnConfiguring);
 
                 var dbContextFileName = ContextTransformationService.TransformContextFileName(options.ContextName) + ".cs";
-                resultingFiles.ContextFile = new ScaffoldedFile(options.ContextDir != null
+                var dbContextPath = options.ContextDir != null
                     ? Path.Combine(options.ContextDir, dbContextFileName)
-                    : dbContextFileName, generatedCode);
+                    : dbContextFileName;
+                resultingFiles.ContextFile = new ScaffoldedFile(dbContextPath, generatedCode);
             }
 
             if (!(CSharpEntityTypeGenerator is NullCSharpEntityTypeGenerator))

--- a/src/EntityFrameworkCore.Scaffolding.Handlebars/Internal/Check.cs
+++ b/src/EntityFrameworkCore.Scaffolding.Handlebars/Internal/Check.cs
@@ -34,7 +34,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Internal
             {
                 NotEmpty(parameterName, nameof(parameterName));
 
-                throw new ArgumentException(AbstractionsStrings.CollectionArgumentIsEmpty(parameterName));
+                throw new ArgumentException(AbstractionsStrings.CollectionArgumentIsEmpty, parameterName);
             }
 
             return value;
@@ -50,7 +50,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Internal
             }
             else if (value.Trim().Length == 0)
             {
-                e = new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
+                e = new ArgumentException(AbstractionsStrings.ArgumentIsEmpty, parameterName);
             }
 
             if (e != null)
@@ -70,7 +70,7 @@ namespace EntityFrameworkCore.Scaffolding.Handlebars.Internal
             {
                 NotEmpty(parameterName, nameof(parameterName));
 
-                throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty(parameterName));
+                throw new ArgumentException(AbstractionsStrings.ArgumentIsEmpty, parameterName);
             }
 
             return value;

--- a/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
+++ b/test/Scaffolding.Handlebars.Tests/Scaffolding.Handlebars.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>7cd5132a-1f06-4001-b62c-51cdcbe38dbf</UserSecretsId>
@@ -12,14 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Upgrades the solution from .NET 8 / EF Core 9 to **.NET 10 / EF Core 10.0.5**.

### Changes

- **global.json**: SDK `8.0.0` → `10.0.0`
- **Target framework**: `net8.0` → `net10.0` (all projects), `netstandard2.1` → `net10.0` (TemplatesAssembly)
- **Library package version**: `9.0.0` → `10.0.0`

#### NuGet package upgrades
| Package | Old | New |
|---------|-----|-----|
| EF Core (Design, Relational, SqlServer) | 9.0.0 | 10.0.5 |
| Microsoft.Extensions.Configuration.* | 9.0.0 | 10.0.0 |
| Handlebars.Net | 2.1.2 | 2.1.6 |
| JetBrains.Annotations | 2024.3.0 | 2025.2.4 |
| Microsoft.NET.Test.Sdk | 17.12.0 | 18.3.0 |
| xunit | 2.9.2 | 2.9.3 |
| xunit.runner.visualstudio | 2.8.2 | 3.1.5 |
| Microsoft.AspNetCore.OpenApi | 8.0.0 | 10.0.5 |
| Microsoft.VisualStudio.Web.CodeGeneration.Design | 8.0.0 | 10.0.2 |
| Swashbuckle.AspNetCore | 6.4.0 | 10.1.7 |

#### Breaking changes fixed
- **\Check.cs\**: \AbstractionsStrings.CollectionArgumentIsEmpty\ / \ArgumentIsEmpty\ changed from methods to properties in EF Core 10
- **\HbsCSharpModelGenerator.cs\** / **\HbsTypeScriptModelGenerator.cs\**: \ScaffoldedFile\ constructor usage updated

#### README updated
- Prerequisites, Upgrading, and Usage sections updated for .NET 10

### Verification
- ✅ Build succeeded (0 errors)
- ✅ 51/51 tests passed